### PR TITLE
feat: add search engine for hpss-based observations

### DIFF
--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -1,0 +1,64 @@
+import os
+from datetime import datetime
+from obs_inv_utils import hpss_io_interface as hpss
+from obs_inv_utils.config_handler import ObservationsConfig, ObsSearchConfig
+from obs_inv_utils import time_utils
+from obs_inv_utils.time_utils import DateRange
+from obs_inv_utils.hpss_io_interface import HpssTarballContents, HpssFileInfo
+from typing import Optional
+from dataclasses import dataclass, field
+
+
+hpss_inspect_tarball = hpss.hpss_cmds[hpss.CMD_INSPECT_TARBALL]
+
+@dataclass
+class ObsInventorySearchEngine(object):
+    obs_inv_conf: ObservationsConfig
+    search_configs: list[ObsSearchConfig] = field(default_factory=list)
+
+
+    def __post_init__(self):
+        print(f'search_configs: {self.search_configs}')
+        self.search_configs = self.obs_inv_conf.get_obs_inv_search_configs()
+        print(f'search_configs after init: {self.search_configs}')
+
+    def get_obs_file_info(self):
+
+        date_range = self.obs_inv_conf.get_search_date_range()
+        master_list = []
+        print(f'search config date range: {date_range}')
+
+        all_search_paths_finished = False
+        while not all_search_paths_finished:
+            all_search_paths_finished = True
+            for key, search_config in self.search_configs.items():
+                print(f'search_config: {search_config}')
+                search_path = search_config.get_current_search_path()
+                if search_config.get_date_range().at_end():
+                    end = search_config.get_date_range().end
+                    print(f'Finished search, path: {search_path}, end: {end}')
+                    continue
+
+                args = []
+                args.append(search_path)
+                hpss_cmd = hpss.HpssCommandHandler(
+                    hpss.CMD_INSPECT_TARBALL,
+                    args
+                )
+
+                if hpss_cmd.send():
+                     file_info = hpss_cmd.parse_response()
+                     print(f'file_info: {file_info}')
+                     files = file_info.files
+                     for file in files:
+                         master_list.append(file)
+                else:
+                     print(f'hpss_cmd_failed: {hpss_cmd.get_raw_response()}') 
+
+                search_config.get_date_range().increment_day()
+                all_search_paths_finished = False
+                print(f'Current search path: {search_path}')
+
+        print(f'All done')
+        for file_info in master_list:
+            print(f'File info: {file_info}')

--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -1,15 +1,242 @@
+from collections import namedtuple
 import os
+import pathlib
 from datetime import datetime
 from obs_inv_utils import hpss_io_interface as hpss
+from obs_inv_utils import obs_storage_platforms as platforms
 from obs_inv_utils.config_handler import ObservationsConfig, ObsSearchConfig
 from obs_inv_utils import time_utils
 from obs_inv_utils.time_utils import DateRange
-from obs_inv_utils.hpss_io_interface import HpssTarballContents, HpssFileInfo
+from obs_inv_utils.hpss_io_interface import HpssTarballContents, HpssFileMeta
+from obs_inv_utils.hpss_io_interface import HpssCommandRawResponse
 from typing import Optional
 from dataclasses import dataclass, field
+from obs_inv_utils import inventory_table_factory as tbl_factory 
 
+SECONDS_IN_A_DAY = 24*3600
 
 hpss_inspect_tarball = hpss.hpss_cmds[hpss.CMD_INSPECT_TARBALL]
+
+FilenameMeta = namedtuple(
+    'FilenameMeta',
+    [
+        'prefix',
+        'cycle_tag',
+        'data_type',
+        'cycle_time',
+        'data_format',
+        'suffix',
+        'not_restricted_tag'
+    ],
+)
+
+TarballFileMeta = namedtuple(
+    'TarballFileMeta',
+    [
+        'filename',
+        'parent_dir',
+        'platform',
+        's3_bucket',
+        'prefix',
+        'cycle_tag',
+        'data_type',
+        'cycle_time',
+        'obs_day',
+        'data_format',
+        'suffix',
+        'nr_tag',
+        'file_size',
+        'permissions',
+        'last_modified',
+        'submitted_at',
+        'latency',
+        'inserted_at'
+    ],
+)
+
+HpssCmdResult = namedtuple(
+    'HpssCmdResult',
+    [
+        'command',
+        'arg0',
+        'raw_output',
+        'raw_error',
+        'error_code',
+        'obs_day',
+        'submitted_at',
+        'latency'
+    ],
+)
+
+
+# filename parts definitions
+PREFIX = 0
+CYCLE_TAG = 1
+DATA_TYPE = 2
+
+OBS_FORMAT_BUFR = 'bufr'
+OBS_FORMAT_BUFR_D = 'bufr_d'
+OBS_FORMAT_GRB = 'grb'
+OBS_FORMAT_GRIB2 = 'grib2'
+OBS_FORMAT_UNKNOWN = 'unknown'
+OBS_FORMATS = [
+    OBS_FORMAT_BUFR,
+    OBS_FORMAT_BUFR_D,
+    OBS_FORMAT_GRB,
+    OBS_FORMAT_GRIB2
+]
+
+ADDITIONAL_GRIB2_FORMAT_EXTENSIONS = ['1536','576']
+
+
+
+def get_cycle_tag(parts):
+    if not isinstance(parts, list) or len(parts) < 2:
+        return None
+    return parts[CYCLE_TAG]
+
+
+def get_data_type(parts):
+    if not isinstance(parts, list) or len(parts) < 3:
+        return None
+    return parts[DATA_TYPE]
+
+
+def get_cycle_time(tag):
+    try:
+        cycle_time = datetime.strptime(tag, 't%HZ')
+        seconds = (cycle_time - datetime(1900,1,1)).total_seconds()
+    except Exception as e:
+        print(f'Not a valid cycle time: {tag}, error: {e}')
+        return None
+
+    if seconds < 0 or seconds > time_utils.SECONDS_IN_A_DAY:
+        return None
+
+    return int(seconds)
+
+
+def get_data_format(filename):
+    # strip '.nr' from filename
+    if not isinstance(filename, str):
+        return OBS_FORMAT_UNKNOWN
+
+    fn = filename.removesuffix('.nr')
+    file_ext = (pathlib.Path(fn).suffix).replace('.','',1)
+
+    if file_ext in OBS_FORMATS:
+        return file_ext
+
+    for obs_format in OBS_FORMATS:
+        if fn.endswith(obs_format):
+            return obs_format
+
+    if file_ext in ADDITIONAL_GRIB2_FORMAT_EXTENSIONS:
+        return OBS_FORMAT_GRIB2
+
+    for obs_format in OBS_FORMATS:
+        if obs_format in fn:
+            return obs_format
+
+    return OBS_FORMAT_UNKNOWN
+        
+
+def get_combined_suffix(parts):
+    if not isinstance(parts, list) or len(parts) < 4:
+        return None
+
+    suffix_parts = parts[3:]
+    suffix = ''
+    for part in suffix_parts:
+        if not isinstance(part, str):
+            print(f'Bad filename parts: {parts}, each part must be a string')
+            return None
+        suffix += '.' + part
+
+    if suffix == '':
+        return None
+
+    return suffix
+
+
+
+def parse_filename(filename):
+    parts = filename.split('.')
+    cycle_tag = get_cycle_tag(parts)
+    filename_meta = FilenameMeta(
+        parts[PREFIX],
+        cycle_tag,
+        get_data_type(parts),
+        get_cycle_time(cycle_tag),
+        get_data_format(filename),
+        get_combined_suffix(parts),
+        filename.endswith('.nr')
+    )
+
+    return filename_meta
+
+
+def process_inspect_tarball_resp(contents):
+    if not isinstance(contents, hpss.HpssTarballContents):
+        return None
+
+    inspected_files = contents.inspected_files
+
+    tarball_files_meta = []
+    
+    for inspected_file in inspected_files:
+        fn = inspected_file.name
+        print(f'filename: {fn}')
+        fn_meta = parse_filename(fn)
+        print(f'filename meta: {fn_meta}')
+
+        tarball_file_meta = TarballFileMeta(
+            fn,
+            contents.parent_dir,
+            platforms.HERA_HPSS,
+            '',
+            fn_meta.prefix,
+            fn_meta.cycle_tag,
+            fn_meta.data_type,
+            fn_meta.cycle_time,
+            contents.observation_day,
+            fn_meta.data_format,
+            fn_meta.suffix,
+            fn_meta.not_restricted_tag,
+            inspected_file.size,
+            inspected_file.permissions,
+            inspected_file.last_modified,
+            contents.submitted_at,
+            contents.latency,
+            datetime.utcnow()
+        )
+        tarball_files_meta.append(tarball_file_meta)
+
+    tbl_factory.insert_obs_inv_items(tarball_files_meta)
+
+
+def post_hpss_cmd_result(raw_response, obs_day):
+    if not isinstance(raw_response, HpssCommandRawResponse):
+        msg = 'raw_response must be of type HpssCommandRawResponse. It is'\
+              f' actually of type: {type(raw_response)}'
+        raise TypeError(msg)
+
+    hpss_cmd_result = HpssCmdResult(
+        raw_response.command,
+        raw_response.args_0,
+        raw_response.output,
+        raw_response.error,
+        raw_response.return_code,
+        obs_day,
+        raw_response.submitted_at,
+        raw_response.latency
+    )
+        
+    print(f'hpss_cmd_result: {hpss_cmd_result}')
+    tbl_factory.insert_hpss_cmd_result(hpss_cmd_result)
+
+        
+    
 
 @dataclass
 class ObsInventorySearchEngine(object):
@@ -29,36 +256,47 @@ class ObsInventorySearchEngine(object):
         print(f'search config date range: {date_range}')
 
         all_search_paths_finished = False
+        loop_count = 0
         while not all_search_paths_finished:
-            all_search_paths_finished = True
+            print(f'loop {loop_count} of while loop, all_search_paths_finished: {all_search_paths_finished}')
+            loop_count += 1
+            finished_count = 0
             for key, search_config in self.search_configs.items():
                 print(f'search_config: {search_config}')
                 search_path = search_config.get_current_search_path()
+
                 if search_config.get_date_range().at_end():
                     end = search_config.get_date_range().end
+                    finished_count += 1
                     print(f'Finished search, path: {search_path}, end: {end}')
                     continue
 
-                args = []
-                args.append(search_path)
-                hpss_cmd = hpss.HpssCommandHandler(
-                    hpss.CMD_INSPECT_TARBALL,
-                    args
+                args = [search_path]
+                print(f'args: {args}, search_path: {search_path}')
+                cmd = hpss.HpssCommandHandler(hpss.CMD_INSPECT_TARBALL, args)
+                print(f'cmd: {cmd}, finished_count: {finished_count}')
+    
+
+                if cmd.send():
+                    current_day = search_config.get_date_range().current
+                    tarball_contents = cmd.parse_response(current_day)
+                    file_meta = process_inspect_tarball_resp(tarball_contents)
+                    print(f'file_meta: {file_meta}')
+                elif cmd.can_retry_send():
+                    msg = f'Command failed - error code: {cmd.get_error}.' \
+                          'Attempt to resend command.'
+                    print(msg)
+                    continue
+                
+                raw_resp = cmd.get_raw_response()
+
+                post_hpss_cmd_result(
+                    raw_resp,
+                    search_config.get_date_range().current
                 )
 
-                if hpss_cmd.send():
-                     file_info = hpss_cmd.parse_response()
-                     print(f'file_info: {file_info}')
-                     files = file_info.files
-                     for file in files:
-                         master_list.append(file)
-                else:
-                     print(f'hpss_cmd_failed: {hpss_cmd.get_raw_response()}') 
-
                 search_config.get_date_range().increment_day()
-                all_search_paths_finished = False
                 print(f'Current search path: {search_path}')
 
-        print(f'All done')
-        for file_info in master_list:
-            print(f'File info: {file_info}')
+            if finished_count == len(self.search_configs):
+                all_search_paths_finished = True

--- a/src/obs_inv_utils/time_utils.py
+++ b/src/obs_inv_utils/time_utils.py
@@ -3,6 +3,8 @@ from typing import Optional
 from dataclasses import dataclass
 
 
+SECONDS_IN_A_DAY = 24 * 3600
+
 DEFAULT_START_TIME = datetime(year=1990, month=1, day=1)
 DEFAULT_END_TIME = datetime.utcnow()
 DEFAULT_DATE_STR = '%Y%m%dT%H%M%SZ'
@@ -35,9 +37,10 @@ def is_valid_increment_type(value):
 def set_datetime(time_str, format_str):
     try:
         time = datetime.strptime(time_str, format_str)
+        print(f'in set_datetime - time: {time}, time_str: {time_str}, format_str: {format_str}')
     except Exception as e:
-        print(f'Invalid time str: {time_str} or format string: {format_str}. {e}')
-        return None
+        msg = f'Invalid time str: {time_str} or format string: {format_str}. {e}'
+        raise ValueError(msg)
 
     return time
 
@@ -70,13 +73,15 @@ def get_date_range_from_dict(date_range):
 
     if start is None:
         start = DEFAULT_START_TIME
-        msg = f'Warning: invalid start time: {raw_start}, using default: ' \
+        msg = f'Error: invalid start time: {raw_start}, using default: ' \
               f'{DEFAULT_START_TIME}'
+        raise ValueError(msg)
     
     if end is None:
         end = DEFAULT_END_TIME 
-        msg = f'Warning: invalid end time: {raw_end}, using default: ' \
+        msg = f'Error: invalid end time: {raw_end}, using default: ' \
               f'{DEFAULT_END_TIME}'
+        raise ValueError(msg)
 
     print(f'start: {start}, end: {end}')
 
@@ -166,14 +171,13 @@ class DateRange:
 
         if new_time < self.start:
             self.current = self.start
-
-        if new_time > self.end:
+        elif new_time > self.end:
             self.current = self.end
+        else:
+            self.current = new_time
 
-        self.current = new_time
 
-
-    def increment_day(self):
+    def increment_day(self):    
         self.increment(days=1)
 
 

--- a/src/tests/configs/obs_inv_config__valid.yaml
+++ b/src/tests/configs/obs_inv_config__valid.yaml
@@ -1,8 +1,8 @@
 cycling_interval: 21600
 date_range:
   datestr: '%Y%m%dT%H%M%SZ'
-  end: 20190103T000000Z
-  start: 20190101T000000Z
+  end: 20190901T000000Z
+  start: 20190827T000000Z
 search_info:
   -
     platform: hera_hpss

--- a/src/tests/test_hpss_io_interface.py
+++ b/src/tests/test_hpss_io_interface.py
@@ -13,7 +13,7 @@ import subprocess
 from unittest.mock import patch
 from obs_inv_utils.hpss_io_interface import HpssCommandRawResponse
 from tests.cmd_outputs import hpss_cmd_outputs as hpss_outputs
-
+from tests.cmd_outputs import hpss_cmd_helpers as hpss_helpers
 
 VALID_CONFIG_PATH = os.path.join(
         pathlib.Path(__file__).parent.resolve(),
@@ -28,54 +28,6 @@ VALID_FILE_PATH_3 = '/3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/OP_BUFR/2020/gdas.20
 
 
 CMD_INSPECT_TARBALL = hpss.CMD_INSPECT_TARBALL
-
-
-FILE_NOT_FOUND = 'file_not_found'
-
-SUBPROCESS_POPEN_ERROR_ENV = {
-    'SUBPROCESS_ERROR_TYPE': FILE_NOT_FOUND
-}
-
-STDOUT_HTAR_FAILED = 'HTAR: HTAR FAILED\n'
-STDERR_FILE_NOT_FOUND = '[connecting to hpsscore1.fairmont.rdhpcs.noaa.gov/1217]\nERROR: No such file: /foo/bar/abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRTSUVWXYZ-012356.789.idx\nERROR: Fatal error opening index file: /foo/bar/abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRTSUVWXYZ-012356.789.idx\n###WARNING  htar returned non-zero exit status.\n            72 = /apps/hpss/bin/htar -tvf /foo/bar/abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRTSUVWXYZ-012356.789\n'
-RETURN_CODE_FILE_NOT_FOUND = 72
-
-EXPECTED_FILE_NOT_FOUND_RESPONSE = HpssCommandRawResponse(
-    'htar -tvf /foo/bar/abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRTSUVWXYZ-012356.789.idx',
-    72,
-    STDERR_FILE_NOT_FOUND,
-    STDOUT_HTAR_FAILED,
-    False
-) 
-
-SUBPROCESS_COMMUNICATE_FILE_NOT_FOUND = {
-    'SUBPROCESS_COMMUNICATE_STDOUT': STDOUT_HTAR_FAILED,
-    'SUBPROCESS_COMMUNICATE_STDERR': STDERR_FILE_NOT_FOUND,
-    'SUBPROCESS_COMMUNICATE_RETURNCODE': '72'
-}
-
-SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_CONVBUFR = {
-    'SUBPROCESS_COMMUNICATE_STDOUT': hpss_outputs.STDOUT_HTAR_TVF_SUCCEEDED_GDAS_CONVBUFR,
-    'SUBPROCESS_COMMUNICATE_STDERR': hpss_outputs.STDERR_HTAR_TVF_SUCCEEDED,
-    'SUBPROCESS_COMMUNICATE_RETURNCODE': '0'
-}
-
-SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_SATBUFR = {
-    'SUBPROCESS_COMMUNICATE_STDOUT': hpss_outputs.STDOUT_HTAR_TVF_SUCCEEDED_GDAS_SATBUFR,
-    'SUBPROCESS_COMMUNICATE_STDERR': hpss_outputs.STDERR_HTAR_TVF_SUCCEEDED,
-    'SUBPROCESS_COMMUNICATE_RETURNCODE': '0'
-}
-
-SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_GRIB = {
-    'SUBPROCESS_COMMUNICATE_STDOUT': hpss_outputs.STDOUT_HTAR_TVF_SUCCEEDED_GDAS_GRIB,
-    'SUBPROCESS_COMMUNICATE_STDERR': hpss_outputs.STDERR_HTAR_TVF_SUCCEEDED,
-    'SUBPROCESS_COMMUNICATE_RETURNCODE': '0'
-}
-
-
-
-STDERR_HTAR_TVF_SUCCEEDED = ''
-
 
 def test_is_valid_hpss_cmd__invalid_cmd():
     hpss_command = None
@@ -135,39 +87,13 @@ def test_inspect_tarball_args_valid__valid_file_path():
         assert False, msg
 
 
-class MockPopen(object):
-    def __init__(self, args, stdout=None, stderr=None, returncode=None):
-        self.args = args
-        print(f'In subprocess mock, received args: {args}')
-        self.stdout = None
-        self.stderr = None
-        self.returncode = 0
-        if os.environ.get('SUBPROCESS_ERROR_TYPE') == FILE_NOT_FOUND:
-            msg = '[Errno 2] No such file or directory: "htar"'
-            raise FileNotFoundError(msg)
-
-
-    def communicate(self):
-        print(f'In MockOpen: stdout: {self.stdout}')
-        stdout = os.environ.get('SUBPROCESS_COMMUNICATE_STDOUT')
-        if stdout is None:
-            stdout = ''
-        stderr = os.environ.get('SUBPROCESS_COMMUNICATE_STDERR')
-        if stderr is None:
-            stderr = ''
-        returncode = os.environ.get('SUBPROCESS_COMMUNICATE_RETURNCODE')
-        if returncode is not None:
-            self.returncode = int(returncode)
-        return (stdout.encode('utf-8'),stderr.encode('utf-8'),)
-    
-
 def test_send_command__hpss_module_not_loaded():
     hpss_command = None
     args = []
     args.append(VALID_FILE_PATH_1)
 
-    with patch.dict(os.environ, SUBPROCESS_POPEN_ERROR_ENV):
-        subprocess.Popen = MockPopen
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_POPEN_ERROR_ENV):
+        subprocess.Popen = hpss_helpers.MockPopen
         with pytest.raises(FileNotFoundError):
             hpss_command  = hpss.HpssCommandHandler(
                 CMD_INSPECT_TARBALL, args)
@@ -179,9 +105,9 @@ def test_send_command__htar_tvf_file_not_found():
     hpss_command = None
     args = []
     args.append(VALID_FILE_PATH_FILE_NOT_FOUND)
-    expected_output = STDOUT_HTAR_FAILED
-    with patch.dict(os.environ, SUBPROCESS_COMMUNICATE_FILE_NOT_FOUND):
-        subprocess.Popen = MockPopen
+    expected_output = hpss_helpers.STDOUT_HTAR_FAILED
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_COMMUNICATE_FILE_NOT_FOUND):
+        subprocess.Popen = hpss_helpers.MockPopen
         try:
             hpss_command = hpss.HpssCommandHandler(
                 CMD_INSPECT_TARBALL, args)
@@ -193,7 +119,7 @@ def test_send_command__htar_tvf_file_not_found():
         assert success == False
 
         raw_resp = hpss_command.get_raw_response()
-        assert raw_resp.return_code == RETURN_CODE_FILE_NOT_FOUND
+        assert raw_resp.return_code == hpss_helpers.RETURN_CODE_FILE_NOT_FOUND
 
         print(f'raw_resp.error: {raw_resp.error}')
         print(f'raw_resp.output: {raw_resp.output}')
@@ -204,7 +130,7 @@ def test_send_command__htar_tvf_valid_filepath_1():
     hpss_command = None
     args = []
     args.append(VALID_FILE_PATH_1)
-    with patch.dict(os.environ, SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_CONVBUFR):
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_CONVBUFR):
         hpss_command = hpss.HpssCommandHandler(CMD_INSPECT_TARBALL, args)
         success = hpss_command.send()
         assert success == True
@@ -218,7 +144,7 @@ def test_send_command__htar_tvf_valid_filepath_2():
     hpss_command = None
     args = []
     args.append(VALID_FILE_PATH_2)
-    with patch.dict(os.environ, SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_GRIB):
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_GRIB):
         hpss_command = hpss.HpssCommandHandler(CMD_INSPECT_TARBALL, args)
         success = hpss_command.send()
         assert success == True
@@ -232,7 +158,7 @@ def test_send_command__htar_tvf_valid_filepath_3():
     hpss_command = None
     args = []
     args.append(VALID_FILE_PATH_3)
-    with patch.dict(os.environ, SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_SATBUFR):
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_SATBUFR):
         hpss_command = hpss.HpssCommandHandler(CMD_INSPECT_TARBALL, args)
         success = hpss_command.send()
         assert success == True

--- a/src/tests/test_obs_inv_search_engine.py
+++ b/src/tests/test_obs_inv_search_engine.py
@@ -12,7 +12,10 @@ from obs_inv_utils import config_handler as conf
 from datetime import datetime, timedelta
 from collections import namedtuple, OrderedDict
 from obs_inv_utils import time_utils
-from obs_inv_utils import search_engine
+from obs_inv_utils import search_engine as se
+from tests.cmd_outputs import hpss_cmd_helpers as hpss_helpers
+from unittest.mock import patch
+import subprocess
 
 
 PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
@@ -20,9 +23,11 @@ OBS_INV_YAML_CONFIG__VALID = 'obs_inv_config__valid.yaml'
 
 DATA_DIR = 'data'
 CONFIGS_DIR = 'configs'
-
+originalPopen = subprocess.Popen
 
 def test_search_engine__init():
+
+    #subprocess.Popen = hpss_helpers.MockPopen
     conf_filepath = os.path.join(
         PYTEST_CALLING_DIR,
         CONFIGS_DIR,
@@ -32,6 +37,119 @@ def test_search_engine__init():
     obs_conf = conf.ObservationsConfig(conf_filepath)
     obs_conf.load()
     print(f'obs_conf: {obs_conf}')
-    se = search_engine.ObsInventorySearchEngine(obs_conf)
+    inv_search = se.ObsInventorySearchEngine(obs_conf)
 
-    se.get_obs_file_info()
+    with patch.dict(os.environ, hpss_helpers.SUBPROCESS_COMMUNICATE_HTAR_TVF_SUCCEEDED_GDAS_SATBUFR):
+        inv_search.get_obs_file_info()
+
+
+def test_get_cycle_tag():
+    parts = ['gdas','t00Z','sstgrb']
+    assert se.get_cycle_tag(parts) == parts[se.CYCLE_TAG]
+
+    parts = ['gdas']
+    assert se.get_cycle_tag(parts) == None
+
+    parts = 26
+    assert se.get_cycle_tag(parts) == None
+
+    parts = {}
+    assert se.get_cycle_tag(parts) == None
+
+
+def test_get_data_type():
+    parts = ['gdas','t00Z','sstgrb']
+    assert se.get_data_type(parts) == parts[se.DATA_TYPE]
+
+    parts = ['gdas','t00Z']
+    assert se.get_data_type(parts) == None
+
+    parts = 26
+    assert se.get_data_type(parts) == None
+
+    parts = {}
+    assert se.get_data_type(parts) == None
+
+
+def test_get_cycle_time():
+    cycle_tag = 't00Z'
+    assert se.get_cycle_time(cycle_tag) == 0
+
+    cycle_tag = 't06Z'
+    assert se.get_cycle_time(cycle_tag) == 6*3600
+
+    cycle_tag = 't12Z'
+    assert se.get_cycle_time(cycle_tag) == 12*3600
+
+    cycle_tag = 't18Z'
+    assert se.get_cycle_time(cycle_tag) == 18*3600
+
+    cycle_tag = 't26Z'
+    assert se.get_cycle_time(cycle_tag) == None
+
+    cycle_tag = {}
+    assert se.get_cycle_time(cycle_tag) == None
+
+    cycle_tag = 't-06Z'
+    assert se.get_cycle_time(cycle_tag) == None
+
+
+def test_get_data_format():
+    fn = 'gdas.t18z.proflr.tm00.bufr_d.nr'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_BUFR_D
+
+    fn = 'gdas.t00z.imssnow96.grib2'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRIB2
+
+    fn = 'gdas.t00z.nsstbufr'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_BUFR
+
+    fn = 'gdas.t12z.engicegrb'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRB
+
+    fn = 'gdas.t00z.snogrb_t1534.3072.1536'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRIB2
+
+    fn = 'gdas.t00z.snogrb_t574.1152.576'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRIB2
+
+    fn = 'gdas.t18z.seaice.5min.blend.grb'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRB
+
+    fn = 'gdas.t12z.seaice.5min.grb'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_GRB
+
+    fn = 'foo.bas'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_UNKNOWN
+
+    fn = 'gdas.t12z.prepbufr.acft_profiles.nr'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_BUFR
+
+    fn = 'gdas.t12z.prepbufr.nr'
+    assert se.get_data_format(fn) == se.OBS_FORMAT_BUFR
+
+    fn = {}
+    assert se.get_data_format(fn) == se.OBS_FORMAT_UNKNOWN
+
+    fn = 36
+    assert se.get_data_format(fn) == se.OBS_FORMAT_UNKNOWN
+
+    fn = []
+    assert se.get_data_format(fn) == se.OBS_FORMAT_UNKNOWN
+
+
+def test_get_combined_suffix():
+    parts = str('gdas.t00z.snogrb_t1534.3072.1536').split('.')
+    assert se.get_combined_suffix(parts) == '.3072.1536'
+
+    parts = str('gdas.t18z.adpsfc.tm00.bufr_d.nr').split('.')
+    assert se.get_combined_suffix(parts) == '.tm00.bufr_d.nr'
+
+    parts = [26, 48, 6, 392]
+    assert se.get_combined_suffix(parts) == None
+
+    parts = {}
+    assert se.get_combined_suffix(parts) == None
+
+    parts = str('gdas.t18z.adpsfc').split('.')
+    assert se.get_combined_suffix(parts) == None

--- a/src/tests/test_obs_inv_search_engine.py
+++ b/src/tests/test_obs_inv_search_engine.py
@@ -1,0 +1,37 @@
+"""
+Copyright 2022 NOAA
+All rights reserved.
+
+Unit tests for io_utils
+
+"""
+import os
+import pathlib
+import pytest
+from obs_inv_utils import config_handler as conf
+from datetime import datetime, timedelta
+from collections import namedtuple, OrderedDict
+from obs_inv_utils import time_utils
+from obs_inv_utils import search_engine
+
+
+PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
+OBS_INV_YAML_CONFIG__VALID = 'obs_inv_config__valid.yaml'
+
+DATA_DIR = 'data'
+CONFIGS_DIR = 'configs'
+
+
+def test_search_engine__init():
+    conf_filepath = os.path.join(
+        PYTEST_CALLING_DIR,
+        CONFIGS_DIR,
+        OBS_INV_YAML_CONFIG__VALID
+    )
+
+    obs_conf = conf.ObservationsConfig(conf_filepath)
+    obs_conf.load()
+    print(f'obs_conf: {obs_conf}')
+    se = search_engine.ObsInventorySearchEngine(obs_conf)
+
+    se.get_obs_file_info()


### PR DESCRIPTION
body: add a search engine which will run through the specified
observation parent directories (the ones which store the
atmosphere observations used by the UFS-RNR workflow) and parse
all hpss htar -tvf responses for file information.  This search
engine will search over the specified date range and will prepare
the data to be stored in an sqlite db.