### PR TITLE
feat: adding support for aws list_objects_v2

### DIFF
--- a/src/obs_inv_utils/aws_s3_interface.py
+++ b/src/obs_inv_utils/aws_s3_interface.py
@@ -1,0 +1,243 @@
+import re
+import attr
+from collections import namedtuple, OrderedDict
+import boto3
+from datetime import datetime
+from botocore.config import Config
+from botocore import UNSIGNED
+
+
+bdp_config = Config(
+    region_name = 'us-east-1',
+    signature_version = UNSIGNED,
+    retries = {
+        'max_attempts': 10,
+        'mode': 'standard'
+    }
+)
+
+nl = '\n'
+
+AwsS3ObjectsListContents = namedtuple(
+    'AwsS3ObjectsListContents',
+    [
+        'prefix',
+        'files_count',
+        'listed_objects',
+        'obs_cycle_time',
+        'submitted_at',
+        'latency'
+    ],
+)
+
+AwsS3CommandRawResponse = namedtuple(
+    'AwsS3CommandRawResponse',
+    [
+        'command',
+        'return_code',
+        'output',
+        'success',
+        'args_0',
+        'submitted_at',
+        'latency'
+    ],
+)
+
+
+AwsS3FileMeta = namedtuple(
+    'AwsS3FileMeta',
+    [
+        'name',
+        'permissions',
+        'last_modified',
+        'size'
+    ],
+)
+
+
+AwsS3Command = namedtuple(
+    'AwsS3Command',
+    [
+        'command',
+        'arg_validator',
+        'output_parser'
+    ],
+)
+
+AWS_BDP_BUCKET = 'noaa-reanalyses-pds'
+CMD_GET_S3_OBJ_LIST = 'list_objects'
+
+
+def get_bdp_s3_client():
+    try:
+        client = boto3.client('s3', config=bdp_config)
+    except Exception as e:
+        msg = f'Problem getting boto3 s3 client - error: {e}'
+        raise ValueError(msg)
+
+    return client
+
+
+def get_s3_objects_list(client, bucket=None, prefix=None):
+    try:
+        response = client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    except Exception as e:
+        msg = f'Problem getting list for prefix: {prefix}, error: {e}'
+        print(msg)
+
+    return response
+        
+
+def get_objects_list_args_valid(args):
+    if not isinstance(args, list):
+        msg = f'Args must be in the form of a list, args: {args}'
+        raise TypeError(msg)
+    cmd = aws_s3_cmds[CMD_GET_S3_OBJ_LIST].command
+    print(f'{nl}{nl}In inspect tarball args valid: cmd: {cmd}{nl}{nl}')
+    if (len(args) > 1 or len(args) == 0):
+        msg = f'Command "{cmd}" accepts exactly 1 argument, received ' \
+              f'{len(args)}.'
+        raise ValueError(msg)
+
+    arg = args[0]
+
+    try:
+        m = re.search(r'[^A-Za-z0-9\._\-\/]', arg)
+        if m is not None and m.group(0) is not None:
+            print('Only a-z A-Z 0-9 and - . / _ characters allowed in filepath')
+            raise ValueError(f'Invalid characters found in file path: {arg}')
+    except Exception as e:
+        raise ValueError(f'Invalid file path: {e}')
+
+    return True
+
+
+def s3_object_list_v2_parser(obj_list_contents, obs_cycle_time):
+    if not isinstance(obj_list_contents, AwsS3CommandRawResponse):
+        msg = f'Response needs to be an instance type AwsS3CommandRawResponse.'\
+              f'Received type: {type(obj_list_contents)}'
+        raise TypeError(msg)
+
+    # print(f'obs_cycle_time: {obs_cycle_time}, contents: {obj_list_contents}')
+
+    object_list = obj_list_contents.output.get('Contents')
+    # print(f'object_list: {object_list}')
+
+    files_meta = list()
+    prefix = obj_list_contents.args_0
+    permissions = ''
+    file_count = len(object_list)
+
+    for object_item in object_list:
+        print(f'object_item: {object_item}')
+
+        size = object_item.get('Size')
+        last_modified = object_item.get('LastModified')
+        fn_str = object_item.get('Key')
+        fn = fn_str[len(prefix):]
+        
+        print(f'fn: {fn}')
+        files_meta.append(
+            AwsS3FileMeta(fn, permissions, last_modified, size))
+
+    # print(f'files_meta: {files_meta}')
+    return AwsS3ObjectsListContents(
+        prefix,
+        file_count,
+        files_meta,
+        obs_cycle_time,
+        obj_list_contents.submitted_at,
+        obj_list_contents.latency
+    )
+
+
+aws_s3_cmds = {
+    'list_objects': AwsS3Command(
+        get_s3_objects_list,
+        get_objects_list_args_valid,
+        s3_object_list_v2_parser,
+    )
+}
+
+
+def is_valid_aws_s3_cmd(instance, attribute, value):
+    print(f'In is_valid_aws_s3_cmd: value: {value}')
+    if value not in aws_s3_cmds:
+        msg = f'AWS s3 command {value} is not valid. Use one of: ' \
+              f'{aws_s3_cmds.keys()}'
+        raise KeyError(msg)
+    return True
+
+
+@attr.s(slots=True)
+class AwsS3CommandHandler(object):
+
+    command = attr.ib(validator=is_valid_aws_s3_cmd)
+    args = attr.ib(default=attr.Factory(list))
+    kwargs = attr.ib(init=False)
+    cmd_obj = attr.ib(init=False)
+    raw_resp = attr.ib(default=None)
+    submitted_at = attr.ib(default=None)
+    finished_at = attr.ib(default=None)
+    client = attr.ib(init=False)
+
+    def __attrs_post_init__(self):
+        self.cmd_obj = aws_s3_cmds[self.command]
+        print(f'In __attrs_post_init__: self.args: {self.args}')
+        if self.cmd_obj.arg_validator(self.args):
+            self.kwargs = {'bucket': AWS_BDP_BUCKET, 'prefix': self.args[0]}
+
+        self.client = get_bdp_s3_client()
+        print(f'kwargs: {self.kwargs}')
+
+
+    def send(self):
+        try:
+            self.submitted_at = datetime.utcnow()
+            response = self.cmd_obj.command(self.client, **self.kwargs)
+            self.finished_at = datetime.utcnow()
+        except Exception as e:
+            msg = f'Error after sending command {self.command}, error: {e}.'
+            raise ValueError(msg)
+        response_type = type(response)
+        # print(f'type(response): {response_type}, response: {response}')
+        resp_meta = response.get('ResponseMetadata')
+        # print(f'resp_meta: {resp_meta}')
+        self.raw_resp = response
+        returncode = 404
+        contents = response.get('Contents')
+        # print(f'contents: {contents}')
+        if resp_meta is not None:
+            returncode = resp_meta.get('HTTPStatusCode')
+            if contents is None:
+                returncode = 404
+
+        self.raw_resp = AwsS3CommandRawResponse(
+            self.command,
+            returncode,
+            response,
+            (returncode == 200),
+            self.args[0],
+            self.submitted_at,
+            float(self.get_cmd_duration())
+        )
+
+        print(f'raw_resp: {self.raw_resp}')
+
+        return (returncode == 200)
+
+
+    def get_raw_response(self):
+        return self.raw_resp
+
+
+    def get_cmd_duration(self):
+        diff = self.finished_at - self.submitted_at
+        return (diff.seconds + diff.microseconds/1000000)
+
+
+    def parse_response(self, obs_cycle_time):
+        if self.raw_resp is not None:
+            return self.cmd_obj.output_parser(self.raw_resp, obs_cycle_time)
+        else:
+            return None

--- a/src/obs_inv_utils/config_handler.py
+++ b/src/obs_inv_utils/config_handler.py
@@ -73,7 +73,7 @@ class ObsSearchConfig(object):
             self.date_range = DateRange()
 
     def get_storage_platform(self):
-        return storage_platform
+        return self.storage_platform
 
 
     def get_date_range(self):

--- a/src/tests/configs/obs_inv_config__valid.yaml
+++ b/src/tests/configs/obs_inv_config__valid.yaml
@@ -1,19 +1,19 @@
 cycling_interval: 21600
 date_range:
   datestr: '%Y%m%dT%H%M%SZ'
-  end: 20190901T000000Z
-  start: 20190827T000000Z
+  end: 20000101T000000Z
+  start: 19930101T000000Z
 search_info:
   -
     platform: hera_hpss
-    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/convbufr.nr/OP_BUFR/%Y/gdas.%Y%m%d_convbufr.nr.tar
+    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/convbufr.nr/CFSR_BUFR/%Y/gdas.%Y%m%d_convbufr.nr.tar
   -
     platform: hera_hpss
-    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/grib/OP_BUFR/%Y/gdas.%Y%m%d_grib.tar
+    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/grib/CFSR_BUFR/%Y/gdas.%Y%m%d_grib.tar
   -
     platform: hera_hpss
-    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/OP_BUFR/%Y/gdas.%Y%m%d_satbufr.tar
+    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/CFSR_BUFR/%Y/gdas.%Y%m%d_satbufr.tar
   -
     platform: hera_hpss
-    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/OP_BUFR/%Y/gdas.%Y%m%d_satbufr.tar
+    key: /3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/CFSR_BUFR/%Y/gdas.%Y%m%d_satbufr.tar
 

--- a/src/tests/configs/obs_inv_config__valid_s3.yaml
+++ b/src/tests/configs/obs_inv_config__valid_s3.yaml
@@ -1,0 +1,10 @@
+cycling_interval: 21600
+date_range:
+  datestr: '%Y%m%dT%H%M%SZ'
+  end: 20210101T000000Z
+  start: 19900512T000000Z
+search_info:
+  -
+    platform: aws_s3
+    key: observations/atmos/gefsv13_reanalysis-md5/%Y%m%d%H%M%S/bufr/
+

--- a/src/tests/test_aws_s3_interface.py
+++ b/src/tests/test_aws_s3_interface.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2022 NOAA
+All rights reserved.
+
+Unit tests for io_utils
+
+"""
+import os
+import pathlib
+import pytest
+from obs_inv_utils import aws_s3_interface as s3
+from unittest.mock import patch
+from obs_inv_utils import config_handler as conf
+from datetime import datetime, timedelta
+from collections import namedtuple, OrderedDict
+from obs_inv_utils import time_utils
+from obs_inv_utils import search_engine as se
+from tests.cmd_outputs import hpss_cmd_helpers as hpss_helpers
+from unittest.mock import patch
+import subprocess
+VALID_CONFIG_PATH = os.path.join(
+        pathlib.Path(__file__).parent.resolve(),
+        'configs'
+)
+
+BDP_BUCKET = 'noaa-reanalyses-pds'
+
+VALID_FILE_PATH_FILE_NOT_FOUND = '/foo/bar/abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRTSUVWXYZ-012356.789'
+VALID_PREFIX_1 = 'observations/atmos/gefsv13_reanalysis-md5/20190819000000/bufr/'
+VALID_FILE_PATH_2 = '/3year/NCEPDEV/GEFSRR/GDAS_OBS/grib/OP_BUFR/2020/gdas.20200120_grib.tar'
+VALID_FILE_PATH_3 = '/3year/NCEPDEV/GEFSRR/GDAS_OBS/satbufr/OP_BUFR/2020/gdas.20200120_satbufr.tar'
+
+
+#def test_send_command__get_s3_obj_list_valid_key():
+#    client = s3.get_bdp_s3_client()
+#    s3.get_s3_objects_list(client, BDP_BUCKET, VALID_PREFIX_1)
+    # s3_command = s3.AwsS3CommandHandler(s3.CMD_GET_S3_OBJ_LIST, args)
+    # success = s3_command.send()
+    # assert success == True
+
+    #obj_metadata = s3_command.parse_response()
+    #assert len(tarball_contents.files) == tarball_contents.expected_count
+    #assert tarball_contents.parent_dir == VALID_FILE_PATH_1
+
+
+
+
+PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
+OBS_INV_YAML_CONFIG__VALID = 'obs_inv_config__valid_s3.yaml'
+
+DATA_DIR = 'data'
+CONFIGS_DIR = 'configs'
+
+def test_search_engine__init():
+
+    conf_filepath = os.path.join(
+        PYTEST_CALLING_DIR,
+        CONFIGS_DIR,
+        OBS_INV_YAML_CONFIG__VALID
+    )
+
+    obs_conf = conf.ObservationsConfig(conf_filepath)
+    obs_conf.load()
+    print(f'obs_conf: {obs_conf}')
+    client = s3.get_bdp_s3_client()
+    inv_search = se.ObsInventorySearchEngine(obs_conf)
+
+    inv_search.get_obs_file_info()


### PR DESCRIPTION
body: In order to get the inventory of observation files stored in
our BDP aws s3 bucket 'noaa-reanalyses-pds' we needed to add
support for the boto3 function list_objects_v2.  We also needed
to add handling for the database insertion for the command result
and the individual file meta.