### PR TITLE
feat: introduce external obs intervals on obs grouping plots

### DIFF
--- a/src/config_handlers/obsgrp_fs_plot_conf.py
+++ b/src/config_handlers/obsgrp_fs_plot_conf.py
@@ -10,17 +10,19 @@ class ObsFamily:
     yaml_loader: YamlLoader
     data_type_family_name: str
     data_type_family_members: list
+    external_obs_intervals: list
 
     def __post_init__(self):
         print(f'data_type_family_name: {self.data_type_family_name}')
         print(f'data_type_family_members: {self.data_type_family_members}')
         for family_member in self.data_type_family_members:
             print(f'type(family_member): {type(family_member)}')
+            if family_member is None:
+                continue
             if (family_member.get('data_type') is None or
                     family_member.get('suffix') is None):
                 msg = f'data type family member did not contain both ' \
                     f'data_type\' and \'suffix\' keys.'
-                raise KeyError(msg)
 
     def get_members(self):
         return self.data_type_family_members
@@ -28,6 +30,8 @@ class ObsFamily:
     def get_family_name(self):
         return self.data_type_family_name
 
+    def get_ext_obs_intrvls(self):
+        return self.external_obs_intervals
 
 @dataclass
 class ObsGrouping:
@@ -54,14 +58,32 @@ class ObsGrouping:
             print(
                 f'family_name: {family_name}, data_type_family: {data_type_family}')
 
-            family_members = self.yaml_loader.get_value(
-                key='family_members',
-                document=data_type_family,
-                return_type=list
-            )
+            try:
+                family_members = self.yaml_loader.get_value(
+                    key='family_members',
+                    document=data_type_family,
+                    return_type=list
+                )
+            except Exception as e:
+                print(f'No family members found.')
+                family_members = []
+
+            try:
+                ext_obs_intrvls = self.yaml_loader.get_value(
+                    key='external_obs_intervals',
+                    document=data_type_family,
+                    return_type=list
+                )
+            except Exception as e:
+                ext_obs_intrvls = []
+                print(f'No external intervals found')
 
             obs_family = ObsFamily(
-                self.yaml_loader, family_name, family_members)
+                self.yaml_loader,
+                family_name,
+                family_members,
+                ext_obs_intrvls
+            )
 
             print(f'{os.linesep}type(obs_family): {type(obs_family)}')
 

--- a/src/obs_inv_utils/plot_generator.py
+++ b/src/obs_inv_utils/plot_generator.py
@@ -15,8 +15,8 @@ from config_handlers.obsgrp_fs_plot_conf import ObsGrouping, ObsFamily
 
 CALLING_DIR = pathlib.Path(__file__).parent.resolve()
 
-DEFAULT_MIN_DATETIME = datetime.strptime('1989-12-30', '%Y-%m-%d')
-DEFAULT_MAX_DATETIME = datetime.strptime('2021-01-01', '%Y-%m-%d')
+DEFAULT_MIN_DATETIME = datetime.strptime('1987-12-30', '%Y-%m-%d')
+DEFAULT_MAX_DATETIME = datetime.strptime('2023-01-01', '%Y-%m-%d')
 
 OBS_INV_DATERANGE = pd.date_range(
     DEFAULT_MIN_DATETIME,
@@ -29,6 +29,9 @@ OBS_INV_DATERANGE_6H_CYCLE = pd.date_range(
     DEFAULT_MAX_DATETIME,
     freq='6H'
 )
+
+EXT_OBS_ERA5 = 'era5'
+EXT_OBS_MERA20CR = 'mera20cr'
 
 print(f'OBS_INV_DATERANGE: {OBS_INV_DATERANGE}')
 
@@ -54,20 +57,33 @@ class ObsGroupFilesizeTimeline(object):
             fig.suptitle(figure_title, y=0.95, fontsize=20)
 
             for idx, family in enumerate(families):
+                mx_fl_sz = -1000000
                 plt.subplot(fmly_cnt, 1, idx+1)
-                print(f'{os.linesep}family: {family}')
+                print(
+                    f'{os.linesep}family: {family}, len(families): {len(families)}')
 
-                data = oiq.get_family_fs_data(family)
-                data['generic_fn'] = data['prefix'] + \
-                    '.tag.' + data['data_type'] + data['suffix']
-                print(f'data: {data}')
-                print(f'type(ax): {type(ax)}')
                 members = family.get_members()
+                print(f'members: {members}')
+                if len(members) > 0:
+                    data = oiq.get_family_fs_data(family)
+                    data['generic_fn'] = data['prefix'] + \
+                        '.tag.' + data['data_type'] + data['suffix']
+                    print(f'data: {data}')
+                    print(f'type(ax): {type(ax)}')
+                    mx_fl_sz = -(data['file_size'].max())
+                    print(f'mx_fl_sz: {mx_fl_sz}')
+
                 if type(ax) == np.ndarray:
                     ax_sub = ax[idx]
                 else:
                     ax_sub = ax
-                for member in members:
+
+                # set color set.
+                prop_cycle = plt.rcParams['axes.prop_cycle']
+                colors = prop_cycle.by_key()['color']
+                for m_idx, member in enumerate(members):
+                    if len(members) == 0:
+                        continue
                     data_type = member.get('data_type')
                     xy = data.loc[
                         data['data_type'] == data_type
@@ -75,34 +91,78 @@ class ObsGroupFilesizeTimeline(object):
 
                     print(f'file_meta: {xy}')
                     xy.set_index('obs_day', inplace=True)
-                    max_file_size = xy['file_size'].max()
-                    print(f'max_file_size: {max_file_size/1000000}')
+                    # max_file_size = xy['file_size'].max()
+
                     xy_new = xy.reindex(
                         OBS_INV_DATERANGE_6H_CYCLE,
-                        fill_value=-(max_file_size*0.1)
+                        fill_value=mx_fl_sz*0.1
                     )
 
                     x = xy_new.index
                     y = xy_new['file_size']
-                    ax_sub.plot(x, y/1000000, linewidth=0.3, label=data_type)
-                    leg = ax_sub.legend(loc='center left', facecolor="white")
+                    ax_sub.plot(x, y/1000000, linewidth=1,
+                                label=data_type, color=colors[m_idx+2])
 
-                    leg_lines = leg.get_lines()
-                    print(f'leg_lines: {leg_lines}')
-                    # leg_texts = leg.get_texts()
+                    # plt.setp(leg_texts, fontsize=10)
 
-                    for leg_line in leg_lines:
-                        leg_line.set_linewidth(4)
-                        # plt.setp(leg_texts, fontsize=10)
+                ext_obs = family.get_ext_obs_intrvls()
+                print(f'ext_obs: {ext_obs}')
+
+                # overlay external observation intervals on each subplot
+                for ext_ob in ext_obs:
+                    source = ext_ob.get('obs_src')
+                    if source == EXT_OBS_ERA5:
+                        ln_color = colors[0]
+                        y_lvl = mx_fl_sz*0.2/1000000
+                    elif source == EXT_OBS_MERA20CR:
+                        ln_color = colors[1]
+                        y_lvl = mx_fl_sz*0.3/1000000
+                    else:
+                        ln_color = 'grey'
+                        y_lvl = mx_fl_sz*0.4/1000000
+
+                    y = [y_lvl, y_lvl]
+
+                    intervals = ext_ob.get('intervals', [])
+
+                    for intrvl_idx, interval in enumerate(intervals):
+                        x = []
+                        start = datetime.strptime(
+                            interval.get('start'), '%m-%d-%Y')
+                        if start < DEFAULT_MIN_DATETIME:
+                            start = DEFAULT_MIN_DATETIME
+                        x.append(start)
+                        end = datetime.strptime(
+                            interval.get('end'), '%m-%d-%Y')
+                        if end > DEFAULT_MAX_DATETIME:
+                            end = DEFAULT_MAX_DATETIME
+                        x.append(end)
+                        if intrvl_idx == 0:
+                            ax_sub.plot(x, y, linewidth=6,
+                                        label=source, color=ln_color)
+                        else:
+                            ax_sub.plot(x, y, linewidth=8, color=ln_color)
+
+                leg = ax_sub.legend(loc='center right', facecolor="white")
+                plt.ylim((mx_fl_sz*0.4/1000000, -mx_fl_sz*1.1/1000000))
+
+                leg_lines = leg.get_lines()
+                print(f'leg_lines: {leg_lines}')
+                # leg_texts = leg.get_texts()
+
+                for leg_line in leg_lines:
+                    leg_line.set_linewidth(4)
 
                 subplot_title = family.get_family_name()
                 print(f'ax_sub: {ax_sub}')
 
                 ax_sub.minorticks_on()
-                ax_sub.text(0.02, 0.85, subplot_title,
+                ax_sub.text(0.01, 0.8, subplot_title,
                             transform=ax_sub.transAxes, fontsize=15, backgroundcolor='white')
-                ax_sub.grid(which='both', color='grey',
+                ax_sub.grid(which='minor', color='grey',
                             linestyle='--', linewidth=0.2)
+                ax_sub.grid(which='major', color='grey',
+                            linestyle='--', linewidth=0.8)
                 plt.ylabel('File Size(Mb)', fontsize=15)
 
             plt.gcf().autofmt_xdate()
@@ -122,6 +182,7 @@ class ObsGroupFilesizeTimeline(object):
             )
             print(f'saving figure to {dest_path_png}')
             plt.savefig(dest_path_png)
+            # exit(1)
 
 
 @dataclass
@@ -134,12 +195,11 @@ class ObsInvFilesizeTimeline(object):
                   f'be greater than or equal to 0.'
             raise ValueError(msg)
 
-
     def plot_timeline(self):
         data = oiq.get_filesize_timeline_data(self.min_instances)
 
         # due to duplicate inserts of the same file, we need to select only
-        # the most recent insert.  Mutliple inserts can occur due to 
+        # the most recent insert.  Mutliple inserts can occur due to
         # multiple runs of the inventory search tool.  The most recent
         # insert is considered the current status of that file.  After
         # this operation, we should have a current and unique set of filenames
@@ -156,7 +216,7 @@ class ObsInvFilesizeTimeline(object):
         # this new column will now be in the datetime format but will not
         # be set to a specific date.  So adding this new column to the
         # 'obs_day' column will help create a new 'obs_cycle_time' column
-        # which defines a combination of the 'obs_day' and 
+        # which defines a combination of the 'obs_day' and
         # 'cycle_time_datetime'.
         # for example: 'cycle_time_datetime' = 01/01/1970T06:00:00
         # 'obs_day' = 01/01/2014T00:00:00 => 'obs_cycle_time' =
@@ -245,4 +305,3 @@ class ObsInvFilesizeTimeline(object):
             )
             print(f'saving figure to {dest_path_png}')
             plt.savefig(dest_path_png)
-

--- a/src/obs_inv_utils/plot_generator.py
+++ b/src/obs_inv_utils/plot_generator.py
@@ -65,6 +65,11 @@ class ObsGroupFilesizeTimeline(object):
                 members = family.get_members()
                 print(f'members: {members}')
                 if len(members) > 0:
+
+                    # if there are any family members, collect file meta
+                    # data from our obs_inventory table.  This is based
+                    # on our archive stored on AWS s3 bdp bucket
+
                     data = oiq.get_family_fs_data(family)
                     data['generic_fn'] = data['prefix'] + \
                         '.tag.' + data['data_type'] + data['suffix']
@@ -91,7 +96,6 @@ class ObsGroupFilesizeTimeline(object):
 
                     print(f'file_meta: {xy}')
                     xy.set_index('obs_day', inplace=True)
-                    # max_file_size = xy['file_size'].max()
 
                     xy_new = xy.reindex(
                         OBS_INV_DATERANGE_6H_CYCLE,
@@ -102,8 +106,6 @@ class ObsGroupFilesizeTimeline(object):
                     y = xy_new['file_size']
                     ax_sub.plot(x, y/1000000, linewidth=1,
                                 label=data_type, color=colors[m_idx+2])
-
-                    # plt.setp(leg_texts, fontsize=10)
 
                 ext_obs = family.get_ext_obs_intrvls()
                 print(f'ext_obs: {ext_obs}')
@@ -148,7 +150,6 @@ class ObsGroupFilesizeTimeline(object):
 
                 leg_lines = leg.get_lines()
                 print(f'leg_lines: {leg_lines}')
-                # leg_texts = leg.get_texts()
 
                 for leg_line in leg_lines:
                     leg_line.set_linewidth(4)
@@ -182,7 +183,6 @@ class ObsGroupFilesizeTimeline(object):
             )
             print(f'saving figure to {dest_path_png}')
             plt.savefig(dest_path_png)
-            # exit(1)
 
 
 @dataclass

--- a/src/tests/configs/plot_config__data_type_groupings.yaml
+++ b/src/tests/configs/plot_config__data_type_groupings.yaml
@@ -2,7 +2,37 @@
 plot_groupings:
 - grouping_name: Hyperspectral Infrared
   data_type_families:
+  - data_type_family_name: airs
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 10-01-2002
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 10-01-2002
+        end: 01-01-2030
+    family_members:
+    - data_type: airs
+      suffix: ".tm00.bufr_d"
+    - data_type: airsev
+      suffix: ".tm00.bufr_d"
+    - data_type: airswm
+      suffix: ".tm00.bufr_d"
   - data_type_family_name: cris
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2015
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-2013
+        end: 01-01-2030
     family_members:
     - data_type: cris
       suffix: ".tm00.bufr_d"
@@ -11,6 +41,17 @@ plot_groupings:
     - data_type: crisdb
       suffix: ".tm00.bufr_d"
   - data_type_family_name: iasi
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 02-01-2007
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 10-01-2008
+        end: 01-01-2030
     family_members:
     - data_type: iasidb
       suffix: ".tm00.bufr_d"
@@ -18,17 +59,20 @@ plot_groupings:
       suffix: ".tm00.bufr_d"
     - data_type: mtiasi
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: airs
-    family_members:
-    - data_type: airs
-      suffix: ".tm00.bufr_d"
-    - data_type: airsev
-      suffix: ".tm00.bufr_d"
-    - data_type: airswm
-      suffix: ".tm00.bufr_d"
 - grouping_name: Conventional
   data_type_families:
   - data_type_family_name: prepbufr
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1979
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1990
+        end: 01-01-2030
     family_members:
     - data_type: prepbufr
       suffix: ".nr"
@@ -36,9 +80,20 @@ plot_groupings:
     family_members:
     - data_type: prepbufr
       suffix: ".acft_profiles.nr"
-- grouping_name: Geo Radiances
+- grouping_name: Geostationary Radiance
   data_type_families:
   - data_type_family_name: goes
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 05-01-2001
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 05-01-2001
+        end: 01-01-2030
     family_members:
     - data_type: goesnd
       suffix: ".tm00.bufr_d"
@@ -49,6 +104,17 @@ plot_groupings:
 - grouping_name: Multispectral Infrared
   data_type_families:
   - data_type_family_name: HIRS
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1979
+        end: 01-01-2016
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 05-01-1997
+        end: 01-01-2016
     family_members:
     - data_type: 1bhrs2
       suffix: ".tm00.bufr_d"
@@ -58,27 +124,66 @@ plot_groupings:
       suffix: ".tm00.bufr_d"
     - data_type: eshrs3
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: seviri
+  - data_type_family_name: SEVIRI
+    external_obs_intervals:
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 02-01-2012
+        end: 01-01-2030
     family_members:
     - data_type: sevcsr
+      suffix: ".tm00.bufr_d"
+  - data_type_family_name: SSU
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1979
+        end: 03-01-2006
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 05-01-1997
+        end: 03-01-2006
+    family_members:
+    - data_type: 1bssu
       suffix: ".tm00.bufr_d"
   - data_type_family_name: TOVS
     family_members:
     - data_type: rtovs
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: ssu
-    family_members:
-    - data_type: 1bssu
-      suffix: ".tm00.bufr_d"
 - grouping_name: Microwave Images
   data_type_families:
   - data_type_family_name: amsr
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-2012
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 10-01-2012
+        end: 01-01-2030
     family_members:
     - data_type: amsr2
       suffix: ".tm00.bufr_d"
     - data_type: amsr-e
       suffix: ".tm00.bufr_d"
   - data_type_family_name: ssmis
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-1987
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1997
+        end: 01-01-2010
     family_members:
     - data_type: ssmipn
       suffix: ".tm00.bufr_d"
@@ -89,34 +194,44 @@ plot_groupings:
     - data_type: ssmip
       suffix: ".tm00.bufr_d"
   - data_type_family_name: TRMM
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-2005
+        end: 02-01-2015
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1998
+        end: 06-01-2014
     family_members:
     - data_type: trmm
       suffix: ".tm00.bufr_d"
     - data_type: sptrmm
       suffix: ".tm00.bufr_d"
-- grouping_name: Microwave Images
-  data_type_families:
-  - data_type_family_name: amsr
+  - data_type_family_name: GMI
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-2014
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 06-01-2014
+        end: 01-01-2030
     family_members:
-    - data_type: amsr2
-      suffix: ".tm00.bufr_d"
-    - data_type: amsr-e
-      suffix: ".tm00.bufr_d"
-  - data_type_family_name: ssmis
+  - data_type_family_name: amsr-e
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2009
+        end: 10-01-2011
     family_members:
-    - data_type: ssmipn
-      suffix: ".tm00.bufr_d"
-    - data_type: ssmit
-      suffix: ".tm00.bufr_d"
-    - data_type: ssmisu
-      suffix: ".tm00.bufr_d"
-    - data_type: ssmip
-      suffix: ".tm00.bufr_d"
-  - data_type_family_name: TRMM
-    family_members:
-    - data_type: trmm
-      suffix: ".tm00.bufr_d"
-    - data_type: sptrmm
+    - data_type: amsre
       suffix: ".tm00.bufr_d"
 - grouping_name: Microwave Sounders
   data_type_families:
@@ -125,12 +240,34 @@ plot_groupings:
     - data_type: saphir
       suffix: ".tm00.bufr_d"
   - data_type_family_name: mhs
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2006
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 06-01-2005
+        end: 01-01-2030
     family_members:
     - data_type: 1bmhs
       suffix: ".tm00.bufr_d"
     - data_type: esmhs
       suffix: ".tm00.bufr_d"
   - data_type_family_name: atms
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 10-01-2012
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-2012
+        end: 01-01-2030
     family_members:
     - data_type: atms
       suffix: ".tm00.bufr_d"
@@ -138,25 +275,64 @@ plot_groupings:
       suffix: ".tm00.bufr_d"
     - data_type: esatms
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: amsua
+  - data_type_family_name: amsu-a
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-1998
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1999
+        end: 01-01-2030
     family_members:
     - data_type: esamua
       suffix: ".tm00.bufr_d"
     - data_type: 1bamua
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: amsub
+  - data_type_family_name: amsu-b
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-2001
+        end: 01-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1999
+        end: 01-01-2010
     family_members:
     - data_type: esamub
       suffix: ".tm00.bufr_d"
     - data_type: 1bamub
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: 1bmsu
+  - data_type_family_name: msu
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1979
+        end: 11-01-2006
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1997
+        end: 11-01-2006
     family_members:
     - data_type: 1bmsu
       suffix: ".tm00.bufr_d"
 - grouping_name: Snow Cover
   data_type_families:
   - data_type_family_name: imssnow
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2004
+        end: 01-01-2030
     family_members:
     - data_type: imssnow96
       suffix: ".grib2"
@@ -164,9 +340,15 @@ plot_groupings:
     family_members:
     - data_type: snogrb_t1534
       suffix: ".3072.1536"
-- grouping_name: Advanced Vidicon Camera System
+- grouping_name: SST Radiance
   data_type_families:
-  - data_type_family_name: avcs
+  - data_type_family_name: avhrr
+    external_obs_intervals:
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 01-01-1999
+        end: 01-01-2030
     family_members:
     - data_type: avcsam
       suffix: ".tm00.bufr_d"
@@ -176,7 +358,15 @@ plot_groupings:
       suffix: ".tm00.bufr_d"
     - data_type: avcs18
       suffix: ".tm00.bufr_d"
+- grouping_name: Atmospheric Motion Vectors
+  data_type_families:
   - data_type_family_name: wnd
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1982
+        end: 01-01-2030
     family_members:
     - data_type: satwnd
       suffix: ".tm00.bufr_d"
@@ -185,6 +375,12 @@ plot_groupings:
 - grouping_name: GPS Radio Occultation Data
   data_type_families:
   - data_type_family_name: gpsro
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2002
+        end: 01-01-2030
     family_members:
     - data_type: gpsro
       suffix: ".tm00.bufr_d"
@@ -199,12 +395,24 @@ plot_groupings:
 - grouping_name: Scatterometer
   data_type_families:
   - data_type_family_name: qks
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-2000
+        end: 01-01-2010
     family_members:
     - data_type: qkscat
       suffix: ".tm00.bufr_d"
     - data_type: qkswnd
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: asc
+  - data_type_family_name: ASCAT
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 02-01-2007
+        end: 01-01-2030
     family_members:
     - data_type: ascatw
       suffix: ".tm00.bufr_d.nr"
@@ -216,7 +424,13 @@ plot_groupings:
       suffix: ".tm00.bufr_d"
     - data_type: wndsat
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: ers
+  - data_type_family_name: ERS
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 03-01-1992
+        end: 01-01-2030
     family_members:
     - data_type: erscat
       suffix: ".tm00.bufr_d"
@@ -225,20 +439,57 @@ plot_groupings:
 - grouping_name: Ozone
   data_type_families:
   - data_type_family_name: gome
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 06-01-1995
+        end: 08-01-2003
+      - 
+        start: 03-01-2007
+        end: 01-01-2030
     family_members:
     - data_type: gome
       suffix: ".tm00.bufr_d"
-  - data_type_family_name: sbu
+  - data_type_family_name: sbuv
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 01-01-1979
+        end: 06-01-2014
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 06-01-1996
+        end: 02-01-2004
     family_members:
     - data_type: osbuv
       suffix: ".tm00.bufr_d"
     - data_type: osbuv8
       suffix: ".tm00.bufr_d"
   - data_type_family_name: mls
+    external_obs_intervals:
+    - obs_src: era5
+      intervals:
+      - 
+        start: 07-01-2004
+        end: 06-01-2030
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 02-01-2004
+        end: 01-01-2030
     family_members:
     - data_type: mls
       suffix: ".tm00.bufr_d"
   - data_type_family_name: omps
+    external_obs_intervals:
+    - obs_src: mera20cr
+      intervals:
+      -
+        start: 03-01-2012
+        end: 01-01-2030
     family_members:
     - data_type: ompsn8
       suffix: ".tm00.bufr_d"


### PR DESCRIPTION
body: Sergey expressed a desire to compare the external observation
data sets availability to our observation archive stored on the
bdp bucket.  This pull request implements that capability.  Now,
'era5' and 'mera20cr' data set intervals will be overlayed onto
observation family subplots (orange line for era5 and blue line for
mera20cr).
In order to accommodate this change, a new section was added to
each observation family config yaml, the handling of the new config
settings was implemented, and the plotting routine was adjusted
accordingly.