### PR TITLE
added etag to the database

### DIFF
--- a/src/obs_inv_utils/aws_s3_interface.py
+++ b/src/obs_inv_utils/aws_s3_interface.py
@@ -53,7 +53,8 @@ AwsS3FileMeta = namedtuple(
         'name',
         'permissions',
         'last_modified',
-        'size'
+        'size',
+        'etag'
     ],
 )
 
@@ -209,11 +210,12 @@ def s3_object_list_v2_parser(obj_list_contents, obs_cycle_time):
         size = object_item.get('Size')
         last_modified = object_item.get('LastModified')
         fn_str = object_item.get('Key')
+        etag = object_item.get('ETag')[1:-1]
         fn = fn_str[len(prefix):]
         
         print(f'fn: {fn}')
         files_meta.append(
-            AwsS3FileMeta(fn, permissions, last_modified, size))
+            AwsS3FileMeta(fn, permissions, last_modified, size, etag))
 
     # print(f'files_meta: {files_meta}')
     return AwsS3ObjectsListContents(

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -62,6 +62,7 @@ def create_obs_inventory_table():
               Column('suffix', String),
               Column('nr_tag', Boolean),
               Column('file_size', Integer),
+              Column('etag', String),
               Column('permissions', String),
               Column('last_modified', DateTime),
               Column('inserted_at', DateTime),
@@ -165,6 +166,7 @@ class ObsInventory(Base):
     suffix = Column(String(63))
     nr_tag = Column(Boolean())
     file_size = Column(Integer())
+    etag = Column(String(34))
     permissions = Column(String(15))
     last_modified = Column(DateTime())
     inserted_at = Column(DateTime())
@@ -220,6 +222,7 @@ def insert_obs_inv_items(obs_inv_items):
             suffix=obs_item.suffix,
             nr_tag=obs_item.nr_tag,
             file_size=obs_item.file_size,
+            etag=obs_item.etag,
             permissions=obs_item.permissions,
             last_modified=obs_item.last_modified,
             inserted_at=obs_item.inserted_at,

--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -54,7 +54,8 @@ TarballFileMeta = namedtuple(
         'last_modified',
         'submitted_at',
         'latency',
-        'inserted_at'
+        'inserted_at',
+        'etag'
     ],
 )
 
@@ -242,7 +243,8 @@ def process_aws_s3_list_objects_v2_resp(cmd_result_id, contents):
             listed_object.last_modified,
             contents.submitted_at,
             contents.latency,
-            datetime.utcnow()
+            datetime.utcnow(),
+            listed_object.etag
         )
         files_meta.append(file_meta)
 
@@ -283,7 +285,8 @@ def process_aws_s3_clean_resp(cmd_result_id, contents):
             listed_object.last_modified,
             contents.submitted_at,
             contents.latency,
-            datetime.utcnow()
+            datetime.utcnow(),
+            listed_object.etag
     ))
 
     if len(files_meta) > 0:
@@ -322,7 +325,8 @@ def process_inspect_tarball_resp(cmd_result_id, contents):
             inspected_file.last_modified,
             contents.submitted_at,
             contents.latency,
-            datetime.utcnow()
+            datetime.utcnow(),
+            ''
         )
         tarball_files_meta.append(tarball_file_meta)
 


### PR DESCRIPTION
closes #31 

This can partially address your concern @HenryWinterbottom-NOAA about database integrity. But we will need to think about a better way to handle this in the future. 

Things changed: 
1) added etag (aka md5 sum) to the classes and tables. 
2) Retrieved etag from s3 object property. 