### PR TITLE
Add MySQL functionality

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,6 @@
+DATABASE_TYPE = 'mysql'
+MYSQL_USERNAME = 'obsinvuser'
+MYSQL_PASSWORD = '{password to your database}'
+MYSQL_HOST = 'observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com'
+MYSQL_DATABASE = 'obsinvdb'
+SQLITE_DATABASE = 'inventory.db'

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -1,3 +1,4 @@
+import os
 import sqlalchemy as db
 from datetime import datetime
 from collections import namedtuple, OrderedDict
@@ -8,13 +9,24 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+import credentials
 
-OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+
 OBS_INVENTORY_TABLE = 'obs_inventory'
 CMD_RESULTS_TABLE = 'cmd_results'
 OBS_META_NCEPLIBS_BUFR_TABLE = 'obs_meta_nceplibs_bufr'
 
-engine = db.create_engine(OBS_SQLITE_DATABASE, echo=True)
+OBS_DATABASE = ''
+OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+database_type = os.getenv('DATABASE_TYPE', 'sqlite')
+if(database_type.lower() == 'mysql'):
+    mysql_password = os.getenv('MYSQL_PASSWORD')
+    OBS_DATABASE = f'mysql://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306'
+else:
+    OBS_DATABASE = OBS_SQLITE_DATABASE
+
+
+engine = db.create_engine(OBS_DATABASE, echo=True)
 Base = declarative_base()
 metadata = MetaData(engine)
 Session = sessionmaker(bind=engine)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -20,7 +20,7 @@ OBS_DATABASE = ''
 OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
 
 database_type = os.getenv('DATABASE_TYPE', 'sqlite')
-print('dt: ' + database_type)
+print('database type: ' + database_type)
 if(database_type.lower() == 'mysql'):
     mysql_password = os.getenv('MYSQL_PASSWORD')
     OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'
@@ -309,7 +309,6 @@ def insert_obs_meta_nceplibs_bufr_item(obs_meta_items):
     session.close()
 
 
-print('about to create tables')
 if(database_type.lower() == 'mysql'):
     Base.metadata.create_all(engine)
 else:
@@ -317,4 +316,3 @@ else:
     create_cmd_results_table()
     create_obs_meta_nceplibs_bufr_table()
 
-print('after creating table')

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -33,11 +33,11 @@ if(database_type.lower() == 'mysql'):
 
     OBS_DATABASE = f'mysql+mysqlconnector://{mysql_username}:{mysql_password}@{mysql_host}:3306/{mysql_database}'
 else:
+    sqlite_database = OBS_SQLITE_DEFAULT
     try: 
         sqlite_database = os.getenv('SQLITE_DATABASE')
     except:
         print('No SQLITE_DATABASE value found in .env file. Defaulting to observations_inventory.db.')
-        sqlite_database = OBS_SQLITE_DEFAULT
         pass
 
     OBS_DATABASE = "sqlite:///" + sqlite_database

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -9,13 +9,13 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import credentials
-import sqlalchemy.dialects.mysql
+from dotenv import load_dotenv
+
+load_dotenv()
 
 OBS_INVENTORY_TABLE = 'obs_inventory'
 CMD_RESULTS_TABLE = 'cmd_results'
 OBS_META_NCEPLIBS_BUFR_TABLE = 'obs_meta_nceplibs_bufr'
-print(os.environ)
 OBS_DATABASE = ''
 # OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
 database_type = os.getenv('DATABASE_TYPE', 'sqlite')
@@ -310,8 +310,11 @@ def insert_obs_meta_nceplibs_bufr_item(obs_meta_items):
 
 
 print('about to create tables')
-#create_obs_inventory_table()
-#create_cmd_results_table()
-#create_obs_meta_nceplibs_bufr_table()
-Base.metadata.create_all(engine)
+if(database_type.lower() == 'mysql'):
+    Base.metadata.create_all(engine)
+else:
+    create_obs_inventory_table()
+    create_cmd_results_table()
+    create_obs_meta_nceplibs_bufr_table()
+
 print('after creating table')

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -27,6 +27,9 @@ if(database_type.lower() == 'mysql'):
         mysql_password = os.getenv('MYSQL_PASSWORD')
         mysql_host = os.getenv('MYSQL_HOST')
         mysql_database = os.getenv('MYSQL_DATABASE')
+
+        if(mysql_username == None or mysql_password == None or mysql_host == None or mysql_database == None):
+            raise Exception
     except: 
         print('There was an error pulling the required values for the MySQL database from the .env file.')
         print('Required values for MySQL database: MYSQL_USERNAME, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_DATABASE.')
@@ -36,6 +39,8 @@ else:
     sqlite_database = OBS_SQLITE_DEFAULT
     try: 
         sqlite_database = os.getenv('SQLITE_DATABASE')
+        if(sqlite_database == None):
+            raise Exception
     except:
         print('No SQLITE_DATABASE value found in .env file. Defaulting to observations_inventory.db.')
         pass

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -43,12 +43,12 @@ else:
             raise Exception
     except:
         print('No SQLITE_DATABASE value found in .env file. Defaulting to observations_inventory.db.')
+        sqlite_database = OBS_SQLITE_DEFAULT
         pass
 
     OBS_DATABASE = f"sqlite:///{sqlite_database}"
-    
+    print('sqlite database: ' + OBS_DATABASE)   
 
-print('database: ' + OBS_DATABASE)
 engine = db.create_engine(OBS_DATABASE, echo=True)
 Base = declarative_base()
 metadata = MetaData(engine)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -17,16 +17,16 @@ OBS_INVENTORY_TABLE = 'obs_inventory'
 CMD_RESULTS_TABLE = 'cmd_results'
 OBS_META_NCEPLIBS_BUFR_TABLE = 'obs_meta_nceplibs_bufr'
 OBS_DATABASE = ''
-# OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+
 database_type = os.getenv('DATABASE_TYPE', 'sqlite')
 print('dt: ' + database_type)
 if(database_type.lower() == 'mysql'):
     mysql_password = os.getenv('MYSQL_PASSWORD')
     OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'
 else:
-#    OBS_DATABASE = OBS_SQLITE_DATABASE
-    print('manually trying')
-    OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:[PASSWORD HERE]@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'    
+    OBS_DATABASE = OBS_SQLITE_DATABASE
+    
 
 print('database: ' + OBS_DATABASE)
 engine = db.create_engine(OBS_DATABASE, echo=True)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -315,4 +315,4 @@ else:
     create_obs_inventory_table()
     create_cmd_results_table()
     create_obs_meta_nceplibs_bufr_table()
-
+    metadata.create_all(engine)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -10,22 +10,25 @@ from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import credentials
-
+import sqlalchemy.dialects.mysql
 
 OBS_INVENTORY_TABLE = 'obs_inventory'
 CMD_RESULTS_TABLE = 'cmd_results'
 OBS_META_NCEPLIBS_BUFR_TABLE = 'obs_meta_nceplibs_bufr'
-
+print(os.environ)
 OBS_DATABASE = ''
-OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+# OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
 database_type = os.getenv('DATABASE_TYPE', 'sqlite')
+print('dt: ' + database_type)
 if(database_type.lower() == 'mysql'):
     mysql_password = os.getenv('MYSQL_PASSWORD')
-    OBS_DATABASE = f'mysql://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306'
+    OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'
 else:
-    OBS_DATABASE = OBS_SQLITE_DATABASE
+#    OBS_DATABASE = OBS_SQLITE_DATABASE
+    print('manually trying')
+    OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:[PASSWORD HERE]@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'    
 
-
+print('database: ' + OBS_DATABASE)
 engine = db.create_engine(OBS_DATABASE, echo=True)
 Base = declarative_base()
 metadata = MetaData(engine)
@@ -306,8 +309,9 @@ def insert_obs_meta_nceplibs_bufr_item(obs_meta_items):
     session.close()
 
 
-
-create_obs_inventory_table()
-create_cmd_results_table()
-create_obs_meta_nceplibs_bufr_table()
-metadata.create_all(engine)
+print('about to create tables')
+#create_obs_inventory_table()
+#create_cmd_results_table()
+#create_obs_meta_nceplibs_bufr_table()
+Base.metadata.create_all(engine)
+print('after creating table')

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -40,7 +40,7 @@ else:
         print('No SQLITE_DATABASE value found in .env file. Defaulting to observations_inventory.db.')
         pass
 
-    OBS_DATABASE = "sqlite:///" + sqlite_database
+    OBS_DATABASE = f"sqlite:///{sqlite_database}"
     
 
 print('database: ' + OBS_DATABASE)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -17,15 +17,30 @@ OBS_INVENTORY_TABLE = 'obs_inventory'
 CMD_RESULTS_TABLE = 'cmd_results'
 OBS_META_NCEPLIBS_BUFR_TABLE = 'obs_meta_nceplibs_bufr'
 OBS_DATABASE = ''
-OBS_SQLITE_DATABASE = 'sqlite:///observations_inventory.db'
+OBS_SQLITE_DEFAULT = 'observations_inventory.db'
 
 database_type = os.getenv('DATABASE_TYPE', 'sqlite')
 print('database type: ' + database_type)
 if(database_type.lower() == 'mysql'):
-    mysql_password = os.getenv('MYSQL_PASSWORD')
-    OBS_DATABASE = f'mysql+mysqlconnector://obsinvuser:{mysql_password}@observation-inventory.cuydilmgclji.us-east-1.rds.amazonaws.com:3306/obsinvdb'
+    try: 
+        mysql_username = os.getenv('MYSQL_USERNAME')
+        mysql_password = os.getenv('MYSQL_PASSWORD')
+        mysql_host = os.getenv('MYSQL_HOST')
+        mysql_database = os.getenv('MYSQL_DATABASE')
+    except: 
+        print('There was an error pulling the required values for the MySQL database from the .env file.')
+        print('Required values for MySQL database: MYSQL_USERNAME, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_DATABASE.')
+
+    OBS_DATABASE = f'mysql+mysqlconnector://{mysql_username}:{mysql_password}@{mysql_host}:3306/{mysql_database}'
 else:
-    OBS_DATABASE = OBS_SQLITE_DATABASE
+    try: 
+        sqlite_database = os.getenv('SQLITE_DATABASE')
+    except:
+        print('No SQLITE_DATABASE value found in .env file. Defaulting to observations_inventory.db.')
+        sqlite_database = OBS_SQLITE_DEFAULT
+        pass
+
+    OBS_DATABASE = "sqlite:///" + sqlite_database
     
 
 print('database: ' + OBS_DATABASE)

--- a/src/obs_inv_utils/obs_inv_queries.py
+++ b/src/obs_inv_utils/obs_inv_queries.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 from obs_inv_utils import inventory_table_factory as itf
 
-engine = db.create_engine(itf.OBS_SQLITE_DATABASE, echo=True)
+engine = db.create_engine(itf.OBS_DATABASE, echo=True)
 Base = declarative_base()
 Session = sessionmaker(bind=engine)
 
@@ -25,7 +25,7 @@ def get_family_fs_data(obs_family):
 
     if not table_exists:
         msg = f'Table \'{itf.OBS_INVENTORY_TABLE}\' does not ' \
-              f'exist in database: \'{itf.OBS_SQLITE_DATABASE}\'.'
+              f'exist in database: \'{itf.OBS_DATABASE}\'.'
         raise ValueError(msg)
 
     session = Session()
@@ -76,7 +76,7 @@ def get_filesize_timeline_data(min_instances):
 
     if not table_exists:
         msg = f'Table \'{itf.OBS_INVENTORY_TABLE}\' does not ' \
-              f'exist in database: \'{itf.OBS_SQLITE_DATABASE}\'.'
+              f'exist in database: \'{itf.OBS_DATABASE}\'.'
         raise ValueError(msg)
 
     session = Session()
@@ -145,7 +145,7 @@ def get_bufr_files_data(filenames, start, end):
 
     if not table_exists:
         msg = f'Table \'{itf.OBS_INVENTORY_TABLE}\' does not ' \
-              f'exist in database: \'{itf.OBS_SQLITE_DATABASE}\'.'
+              f'exist in database: \'{itf.OBS_DATABASE}\'.'
         raise ValueError(msg)
 
     session = Session()


### PR DESCRIPTION
This PR adds the ability to utilize our MySQL database hosted in AWS instead of sqlite. To use the MySQL database, a .env file must be added to the repository which contains DATABASE_TYPE = 'mysql' (case insensitive) and MYSQL_PASSWORD = the password which is provided separately to users. If the .env file does not specify to use MySQL then it will default to the original local sqlite logic. 

The logic has been tested and successfully interacted with the MySQL database. 