### PR TITLE
Improvements and bug fixes to v1

### DIFF
--- a/src/automation/atm_dicts.py
+++ b/src/automation/atm_dicts.py
@@ -127,8 +127,6 @@ avhrr_avcspm = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
-# 10
-
 conv_prepbufr_acft_profiles = InventoryInfo(
     obs_name='conv_prepbufr_acft_profiles',
     key='observations/reanalysis/conv/prepbufr.acft_profiles/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.prepbufr.acft_profiles.nr',
@@ -213,6 +211,30 @@ geo_goesnd = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
+geo_gsrasr = InventoryInfo(
+    obs_name='geo_gsrasr',
+    key='observations/reanalysis/geo/gsrasr/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.gsrasr.tm00.bufr_d',
+    start='20210322T120000Z',
+    s3_prefix='observations/reanalysis/geo/gsrasr/%Y/%m/bufr/',
+    bufr_files='gdas.%z.gsrasr.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+geo_gsrcsr = InventoryInfo(
+    obs_name='geo_gsrcsr',
+    key='observations/reanalysis/geo/gsrcsr/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.gsrcsr.tm00.bufr_d',
+    start='20210322T120000Z',
+    s3_prefix='observations/reanalysis/geo/gsrcsr/%Y/%m/bufr/',
+    bufr_files='gdas.%z.gsrcsr.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
 gmi_nasa_gmiv7 = InventoryInfo(
     obs_name='gmi_nasa_gmiv7',
     key='observations/reanalysis/gmi/nasa/gmi_v7/%Y/%m/bufr/gmi_v7_L1CR.%Y%m%d.t%Hz.bufr',
@@ -248,8 +270,6 @@ gps_gpsro = InventoryInfo(
     cycling_interval=au.CYCLING_6H,
     s3_bucket=au.REANALYSIS_BUCKET,
 )
-
-#20
 
 hirs_1bhrs2 = InventoryInfo(
     obs_name='hirs_1bhrs2',
@@ -371,8 +391,6 @@ ssmi_eumetsat = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
-#30
-
 ssmi_ssmit = InventoryInfo(
     obs_name='ssmi_ssmit',
     key='observations/reanalysis/ssmi/ssmit/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.ssmit.tm00.bufr_d',
@@ -433,10 +451,10 @@ trmm_nasa_tmi = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
-#35
 
+#37 items
 atm_infos = [airs_airsev, airs_aqua, amsua_1bamua, amsua_nasa_aqua, amsua_nasa_r21c, amsub_1bamub, amv_merged, atms_atms,
              avhrr_avcsam, avhrr_avcspm, conv_prepbufr_acft_profiles, conv_prepbufr, cris_cris, cris_crisf4, geo_geoimr,
-             geo_goesfv, geo_goesnd, gmi_nasa_gmiv7, gps_eumetsat, gps_gpsro, hirs_1bhrs2, hirs_1bhrs3, hirs_1bhrs4,
+             geo_goesfv, geo_goesnd, geo_gsrasr, geo_gsrcsr, gmi_nasa_gmiv7, gps_eumetsat, gps_gpsro, hirs_1bhrs2, hirs_1bhrs3, hirs_1bhrs4,
              iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_sbuv_v87, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,
              ssmi_ssmit, ssmis_eumetsat, ssmis_ssmisu, ssu_1bssu, trmm_nasa_tmi]

--- a/src/automation/atm_dicts.py
+++ b/src/automation/atm_dicts.py
@@ -83,7 +83,19 @@ amv_merged = InventoryInfo(
     obs_name='amv_merged',
     key='observations/reanalysis/amv/merged/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.satwnd.tm00.bufr_d',
     start='19790101T000000Z',
-    s3_prefix='observations/reanalysis/amsua/1bamua/%Y/%m/bufr/',
+    s3_prefix='observations/reanalysis/amv/merged/%Y/%m/bufr/',
+    bufr_files='gdas.%z.satwnd.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+amv_satwnd = InventoryInfo(
+    obs_name='amv_satwnd',
+    key='observations/reanalysis/amv/satwnd/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.satwnd.tm00.bufr_d',
+    start='19900101T000000Z',
+    s3_prefix='observations/reanalysis/amv/satwnd/%Y/%m/bufr/',
     bufr_files='gdas.%z.satwnd.tm00.bufr_d',
     nceplibs_cmd=au.NCEPLIBS_SINV,
     platform=au.CLEAN_PLATFORM,
@@ -452,8 +464,8 @@ trmm_nasa_tmi = InventoryInfo(
 )
 
 
-#37 items
-atm_infos = [airs_airsev, airs_aqua, amsua_1bamua, amsua_nasa_aqua, amsua_nasa_r21c, amsub_1bamub, amv_merged, atms_atms,
+#38 items
+atm_infos = [airs_airsev, airs_aqua, amsua_1bamua, amsua_nasa_aqua, amsua_nasa_r21c, amsub_1bamub, amv_merged, amv_satwnd, atms_atms,
              avhrr_avcsam, avhrr_avcspm, conv_prepbufr_acft_profiles, conv_prepbufr, cris_cris, cris_crisf4, geo_geoimr,
              geo_goesfv, geo_goesnd, geo_gsrasr, geo_gsrcsr, gmi_nasa_gmiv7, gps_eumetsat, gps_gpsro, hirs_1bhrs2, hirs_1bhrs3, hirs_1bhrs4,
              iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_sbuv_v87, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,

--- a/src/automation/atm_dicts.py
+++ b/src/automation/atm_dicts.py
@@ -355,12 +355,84 @@ msu_1bmsu = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
-ozone_sbuv_v87 = InventoryInfo(
-    obs_name='ozone_sbuv_v87',
+ozone_cfsr = InventoryInfo(
+    obs_name='ozone_cfsr',
+    key='observations/reanalysis/ozone/cfsr/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.osbuv8.tm00.bufr_d',
+    start='19790101T000000Z',
+    s3_prefix='observations/reanalysis/ozone/cfsr/%Y/%m/bufr/',
+    bufr_files='gdas.%z.osbuv8.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_nasa_sbuv_v87 = InventoryInfo(
+    obs_name='ozone_nasa_sbuv_v87',
     key='observations/reanalysis/ozone/nasa/sbuv_v87/%Y/%m/bufr/sbuv_v87.%Y%m%d.t%Hz.bufr',
     start='19991015T000000Z',
     s3_prefix='observations/reanalysis/ozone/nasa/sbuv_v87/%Y/%m/bufr/', 
     bufr_files='sbuv_v87.%z.bufr',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_ncep_gome = InventoryInfo(
+    obs_name='ozone_ncep_gome',
+    key='observations/reanalysis/ozone/ncep/gome/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.gome.tm00.bufr_d',
+    start='20090101T000000Z',
+    s3_prefix='observations/reanalysis/ozone/ncep/gome/%Y/%m/bufr/',
+    bufr_files='gdas.%z.gome.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_ncep_omi = InventoryInfo(
+    obs_name='ozone_ncep_omi',
+    key='observations/reanalysis/ozone/ncep/omi/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.omi.tm00.bufr_d',
+    start='20100101T000000Z',
+    s3_prefix='observations/reanalysis/ozone/ncep/omi/%Y/%m/bufr/',
+    bufr_files='gdas.%z.omi.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_ncep_ompslp = InventoryInfo(
+    obs_name='ozone_ncep_ompslp',
+    key='observations/reanalysis/ozone/ncep/ompslp/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.ompslp.tm00.bufr_d',
+    start='20210322T120000Z',
+    s3_prefix='observations/reanalysis/ozone/ncep/ompslp/%Y/%m/bufr/',
+    bufr_files='gdas.%z.ompslp.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_ncep_ompsn8 = InventoryInfo(
+    obs_name='ozone_ncep_ompsn8',
+    key='observations/reanalysis/ozone/ncep/ompsn8/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.ompsn8.tm00.bufr_d',
+    start='20210101T000000Z',
+    s3_prefix='observations/reanalysis/ozone/ncep/ompsn8/%Y/%m/bufr/',
+    bufr_files='gdas.%z.ompsn8.tm00.bufr_d',
+    nceplibs_cmd=au.NCEPLIBS_SINV,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+ozone_ncep_ompst8 = InventoryInfo(
+    obs_name='ozone_ncep_ompst8',
+    key='observations/reanalysis/ozone/ncep/ompst8/%Y/%m/bufr/gdas.%Y%m%d.t%Hz.ompst8.tm00.bufr_d',
+    start='20210101T000000Z',
+    s3_prefix='observations/reanalysis/ozone/ncep/ompst8/%Y/%m/bufr/',
+    bufr_files='gdas.%z.ompst8.tm00.bufr_d',
     nceplibs_cmd=au.NCEPLIBS_SINV,
     platform=au.CLEAN_PLATFORM,
     cycling_interval=au.CYCLING_6H,
@@ -468,5 +540,5 @@ trmm_nasa_tmi = InventoryInfo(
 atm_infos = [airs_airsev, airs_aqua, amsua_1bamua, amsua_nasa_aqua, amsua_nasa_r21c, amsub_1bamub, amv_merged, amv_satwnd, atms_atms,
              avhrr_avcsam, avhrr_avcspm, conv_prepbufr_acft_profiles, conv_prepbufr, cris_cris, cris_crisf4, geo_geoimr,
              geo_goesfv, geo_goesnd, geo_gsrasr, geo_gsrcsr, gmi_nasa_gmiv7, gps_eumetsat, gps_gpsro, hirs_1bhrs2, hirs_1bhrs3, hirs_1bhrs4,
-             iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_sbuv_v87, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,
+             iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_nasa_sbuv_v87, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,
              ssmi_ssmit, ssmis_eumetsat, ssmis_ssmisu, ssu_1bssu, trmm_nasa_tmi]

--- a/src/automation/atm_dicts.py
+++ b/src/automation/atm_dicts.py
@@ -536,9 +536,9 @@ trmm_nasa_tmi = InventoryInfo(
 )
 
 
-#38 items
 atm_infos = [airs_airsev, airs_aqua, amsua_1bamua, amsua_nasa_aqua, amsua_nasa_r21c, amsub_1bamub, amv_merged, amv_satwnd, atms_atms,
              avhrr_avcsam, avhrr_avcspm, conv_prepbufr_acft_profiles, conv_prepbufr, cris_cris, cris_crisf4, geo_geoimr,
              geo_goesfv, geo_goesnd, geo_gsrasr, geo_gsrcsr, gmi_nasa_gmiv7, gps_eumetsat, gps_gpsro, hirs_1bhrs2, hirs_1bhrs3, hirs_1bhrs4,
-             iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_nasa_sbuv_v87, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,
+             iasi_mtiasi, mhs_1bmhs, msu_1bmsu, ozone_cfsr, ozone_nasa_sbuv_v87, ozone_ncep_gome, ozone_ncep_omi, ozone_ncep_ompslp,
+             ozone_ncep_ompsn8, ozone_ncep_ompst8, saphir_saphir, seviri_sevcsr, ssmi_eumetsat,
              ssmi_ssmit, ssmis_eumetsat, ssmis_ssmisu, ssu_1bssu, trmm_nasa_tmi]

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -47,11 +47,7 @@ if args.category == 'atmosphere':
     to_inventory = atm_dicts.atm_infos
 if args.category == 'list':
     try:
-        print(f"got list: {args.var_list}")
-        #to_inventory = [i for i in args.var_list if any(i == x.obs_name for x in atm_dicts.atm_infos)]
         to_inventory = [x for x in atm_dicts.atm_infos if any(x.obs_name == i for i in args.var_list)]
-        print(f"to inventory: ")
-        for i in to_inventory: print(i.obs_name)
     except Exception as ex:
         print("An error occurred getting list values to inventory")
         print(ex)

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -52,7 +52,7 @@ if args.category == 'list':
         print("An error occurred getting list values to inventory")
         print(ex)
         quit()
-    if to_inventory is None:
+    if len(to_inventory) == 0:
         print("The provided list did not match available variables.")
         quit()
     if len(to_inventory) != len(args.var_list):

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -48,7 +48,8 @@ if args.category == 'atmosphere':
 if args.category == 'list':
     try:
         print(f"got list: {args.var_list}")
-        to_inventory = [i for i in args.var_list if any(i == x.obs_name for x in atm_dicts.atm_infos)]
+        #to_inventory = [i for i in args.var_list if any(i == x.obs_name for x in atm_dicts.atm_infos)]
+        to_inventory = [x for x in atm_dicts.atm_infos if any(x.obs_name == i for i in args.var_list)]
         print(f"to inventory: ")
         for i in to_inventory: print(i.obs_name)
     except Exception as ex:

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -48,7 +48,7 @@ if args.category == 'atmosphere':
 if args.category == 'list':
     try:
         print(f"got list: {args.var_list}")
-        to_inventory = [i for i in args.var_list if any(i == x.name for x in atm_dicts.atm_infos)]
+        to_inventory = [i for i in args.var_list if any(i == x.obs_name for x in atm_dicts.atm_infos)]
         print(f"to inventory: ")
         for i in to_inventory: print(i.obs_name)
     except Exception as ex:

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -52,6 +52,14 @@ if args.category == 'list':
         print("An error occurred getting list values to inventory")
         print(ex)
         quit()
+    if to_inventory is None:
+        print("The provided list did not match available variables.")
+        quit()
+    if to_inventory.count() != args.var_list.count():
+        print("Some of the items in the list were not available variables.")
+        print("The following items were valid: ")
+        for i in to_inventory: print(i.obs_name)
+        quit()
 
 
 #Import CLI here so that we only connect to the database if the arguments were valid 

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -55,7 +55,7 @@ if args.category == 'list':
     if to_inventory is None:
         print("The provided list did not match available variables.")
         quit()
-    if to_inventory.count() != args.var_list.count():
+    if len(to_inventory) != len(args.var_list):
         print("Some of the items in the list were not available variables.")
         print("The following items were valid: ")
         for i in to_inventory: print(i.obs_name)

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -53,7 +53,7 @@ if args.category == 'list':
         print(ex)
         quit()
     if len(to_inventory) == 0:
-        print("The provided list did not match available variables.")
+        print("The provided list did not match any available variables.")
         quit()
     if len(to_inventory) != len(args.var_list):
         print("Some of the items in the list were not available variables.")

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -22,6 +22,7 @@ parser.add_argument("-cat", dest="category", help="Category of variables to inve
 parser.add_argument("-end", dest="end_date", help=f"End date to use for run. Format expected {au.ESCAPED_DATESTR_FORMAT}. If not provided, uses the current time.", type=str)
 parser.add_argument("-ago", dest="days_ago", help="Number of days before today or a given end_date (defined by the -end argument) over which to run the inventory. If provided, must be positive integer. If not provided, it will run the full extent of the inventory.", default=0, type=int)
 parser.add_argument("-n_jobs", dest="n_jobs", help="Number of parallel jobs to run.", default=18, type=int)
+parser.add_argument("-work_dir", dest="work_dir", help="Location of work directory for nceplibs calls. Defaults to the current directory.", default="./", type=str)
 parser.add_argument("--list", dest="var_list", help="List of the variables to inventory with spaces between each, will only be used if -cat is list", type=str, nargs='+')
 args = parser.parse_args()
 
@@ -103,11 +104,11 @@ def run_nceplibs(inventory_info):
     
     #run correct command as given in dict 
     if inventory_info.nceplibs_cmd == au.NCEPLIBS_SINV:
-        yaml_file = yg.generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time)
+        yaml_file = yg.generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time, args.work_dir)
         cli.get_obs_count_meta_sinv_base(yaml_file)
         os.remove(yaml_file)
     elif inventory_info.nceplibs_cmd == au.NCEPLIBS_CMPBQM:
-        yaml_file = yg.generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_time)
+        yaml_file = yg.generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_time, args.work_dir)
         cli.get_obs_count_meta_cmpbqm_base(yaml_file)
         os.remove(yaml_file)
     else:

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -18,10 +18,11 @@ from pandas import Timestamp
 
 #argparse section
 parser = argparse.ArgumentParser()
-parser.add_argument("-cat", dest="category", help="Category of variables to inventory. Valid options: atmosphere", choices=['atmosphere'], default="atmosphere", type=str)
+parser.add_argument("-cat", dest="category", help="Category of variables to inventory. Valid options: atmosphere", choices=['atmosphere', 'list'], default="atmosphere", type=str)
 parser.add_argument("-end", dest="end_date", help=f"End date to use for run. Format expected {au.DATESTR_FORMAT}. If not provided, uses the current time.", type=str)
 parser.add_argument("-ago", dest="days_ago", help="Number of days before today or a given end_date (defined by the -end argument) over which to run the inventory. If provided, must be positive integer. If not provided, it will run the full extent of the inventory.", default=0, type=int)
 parser.add_argument("-n_jobs", dest="n_jobs", help="Number of parallel jobs to run.", default=18, type=int)
+parser.add_argument("--list", dest="var_list", help="List of the variables to inventory with spaces between each, will only be used if -cat is list", type=str, nargs='+')
 args = parser.parse_args()
 
 #check that input variables are valid 
@@ -44,6 +45,17 @@ if args.days_ago < 0:
 to_inventory = []
 if args.category == 'atmosphere':
     to_inventory = atm_dicts.atm_infos
+if args.category == 'list':
+    try:
+        print(f"got list: {args.var_list}")
+        to_inventory = [i for i in args.var_list if any(i == x.name for x in atm_dicts.atm_infos)]
+        print(f"to inventory: ")
+        for i in to_inventory: print(i.obs_name)
+    except Exception as ex:
+        print("An error occurred getting list values to inventory")
+        print(ex)
+        quit()
+
 
 #Import CLI here so that we only connect to the database if the arguments were valid 
 import obs_inv_utils.obs_inv_cli as cli

--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -19,7 +19,7 @@ from pandas import Timestamp
 #argparse section
 parser = argparse.ArgumentParser()
 parser.add_argument("-cat", dest="category", help="Category of variables to inventory. Valid options: atmosphere", choices=['atmosphere', 'list'], default="atmosphere", type=str)
-parser.add_argument("-end", dest="end_date", help=f"End date to use for run. Format expected {au.DATESTR_FORMAT}. If not provided, uses the current time.", type=str)
+parser.add_argument("-end", dest="end_date", help=f"End date to use for run. Format expected {au.ESCAPED_DATESTR_FORMAT}. If not provided, uses the current time.", type=str)
 parser.add_argument("-ago", dest="days_ago", help="Number of days before today or a given end_date (defined by the -end argument) over which to run the inventory. If provided, must be positive integer. If not provided, it will run the full extent of the inventory.", default=0, type=int)
 parser.add_argument("-n_jobs", dest="n_jobs", help="Number of parallel jobs to run.", default=18, type=int)
 parser.add_argument("--list", dest="var_list", help="List of the variables to inventory with spaces between each, will only be used if -cat is list", type=str, nargs='+')

--- a/src/automation/automation_utils.py
+++ b/src/automation/automation_utils.py
@@ -11,6 +11,7 @@ CLEAN_PLATFORM = 'aws_s3_clean'
 REANALYSIS_BUCKET = 'noaa-reanlyses-pds'
 
 DATESTR_FORMAT = '%Y%m%dT%H%M%SZ'
+ESCAPED_DATESTR_FORMAT = '%%Y%%m%%dT%%H%%M%%SZ'
 
 CYCLING_6H = '21600'
 

--- a/src/automation/yaml_generation.py
+++ b/src/automation/yaml_generation.py
@@ -60,7 +60,7 @@ def generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time
             'end': end
         },
         'bufr_files':[inventory_info.bufr_files],
-        'work_dir': './',
+        'work_dir': '/lustre/home/work/inventory-work/',
         'scrub_files': True
     }
     outfile = open(yaml_file_path, 'w')
@@ -89,7 +89,7 @@ def generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_ti
             'end': end
         },
         'prepbufr_files':[inventory_info.bufr_files],
-        'work_dir': './',
+        'work_dir': '/lustre/home/work/inventory-work/',
         'scrub_files': True
     }
     outfile = open(yaml_file_path, 'w')

--- a/src/automation/yaml_generation.py
+++ b/src/automation/yaml_generation.py
@@ -40,7 +40,7 @@ def generate_obs_inv_config(inventory_info, start_time, end_time):
     return yaml_file_path
 
 # produces the yaml in required format to pass to get_obs_count_meta_sinv cli command
-def generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time):
+def generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time, work_dir):
     filename = inventory_info.obs_name + '_obs_meta_sinv.yaml'
     yaml_file_path = os.path.join(PY_CURRENT_DIR, filename)
     if start_time is dt:
@@ -60,7 +60,7 @@ def generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time
             'end': end
         },
         'bufr_files':[inventory_info.bufr_files],
-        'work_dir': '/lustre/home/work/inventory-work/',
+        'work_dir': work_dir,
         'scrub_files': True
     }
     outfile = open(yaml_file_path, 'w')
@@ -69,7 +69,7 @@ def generate_nceplibs_sinv_inventory_config(inventory_info, start_time, end_time
     return yaml_file_path
 
 # produces the yaml in required format to pass to get_obs_count_meta_cmpbqm cli command
-def generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_time):
+def generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_time, work_dir):
     filename = inventory_info.obs_name + '_obs_meta_cmpbqm.yaml'
     yaml_file_path = os.path.join(PY_CURRENT_DIR, filename)
     if start_time is dt:
@@ -89,7 +89,7 @@ def generate_nceplibs_cmpbqm_inventory_config(inventory_info, start_time, end_ti
             'end': end
         },
         'prepbufr_files':[inventory_info.bufr_files],
-        'work_dir': '/lustre/home/work/inventory-work/',
+        'work_dir': work_dir,
         'scrub_files': True
     }
     outfile = open(yaml_file_path, 'w')

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -51,7 +51,7 @@ else:
     OBS_DATABASE = f"sqlite:///{sqlite_database}"
     print('sqlite database: ' + OBS_DATABASE)   
 
-engine = db.create_engine(OBS_DATABASE, echo=True)
+engine = db.create_engine(OBS_DATABASE)
 Base = declarative_base()
 metadata = MetaData(engine)
 Session = sessionmaker(bind=engine)

--- a/src/obs_inv_utils/plot_generator.py
+++ b/src/obs_inv_utils/plot_generator.py
@@ -32,9 +32,6 @@ OBS_INV_DATERANGE_6H_CYCLE = pd.date_range(
 EXT_OBS_ERA5 = 'era5'
 EXT_OBS_MERA20CR = 'mera20cr'
 
-print(f'OBS_INV_DATERANGE: {OBS_INV_DATERANGE}')
-
-
 @dataclass
 class ObsGroupFilesizeTimeline(object):
     config: ObsGroupFileSizePlotConfig

--- a/src/plotting/plot_mysql_dir_sensor_sat.py
+++ b/src/plotting/plot_mysql_dir_sensor_sat.py
@@ -120,9 +120,14 @@ directory_labels = []
 counter=0
 # for index, row in unique_sat_id.iterrows():
 for index, row in unique_dir_sensor_sats.iterrows():
-    satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
-    if "crisf4" in row['source_dir']:
-        satinfo_string_ = "crisf4_" + utils.sat_dictionary[row['sat_id_name']]
+    try:
+        satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+        if "crisf4" in row['source_dir']:
+            satinfo_string_ = "crisf4_" + utils.sat_dictionary[row['sat_id_name']]
+    except KeyError as err:
+        print(f'unable to get satinfo string for row: {row}')
+        print(f'Error: {err}')
+        satinfo_string_ = row['sensor']
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
 
     pandas.options.mode.chained_assignment = None

--- a/src/plotting/plot_mysql_dir_sensor_sat.py
+++ b/src/plotting/plot_mysql_dir_sensor_sat.py
@@ -101,11 +101,10 @@ height=step*len(unique_dir_sensor_sats)
 #make list of sensor&sat labels 
 sensor_sat_labels = []
 for index, row in unique_dir_sensor_sats.iterrows():
-    source_string = row.source_dir.replace('/', ' ')
     if row.sat_id_name.strip():
-        sensor_sat_labels.append(source_string +  " " + str(row.sat_id_name))
+        sensor_sat_labels.append(str(row.sensor) +  " " + str(row.sat_id_name))
     else:
-        sensor_sat_labels.append(source_string + " " + str(row.sat_id))
+        sensor_sat_labels.append(str(row.sensor) + " " + str(row.sat_id))
 
 print(f"Identified {len(sensor_sat_labels)} unique dir, sensor, sat combos. Generating plot now.")
 

--- a/src/plotting/plot_mysql_sensor_sat.py
+++ b/src/plotting/plot_mysql_sensor_sat.py
@@ -116,7 +116,12 @@ directory_labels = []
 counter=0
 # for index, row in unique_sat_id.iterrows():
 for index, row in unique_sensor_sats.iterrows():
-    satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    try:
+        satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    except KeyError as err:
+        print(f'unable to get satinfo string for row: {row}')
+        print(f'Error: {err}')
+        satinfo_string_ = row['sensor']
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
 
     pandas.options.mode.chained_assignment = None

--- a/src/plotting/plot_mysql_sensor_sat_amv.py
+++ b/src/plotting/plot_mysql_sensor_sat_amv.py
@@ -36,8 +36,8 @@ def plot_one_line(satinfo, dftmp, yloc):
     plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
     plt.plot(dftmp.datetime, yloc*dftmp.active,'|',color='blue',markersize=5)
 
-def select_sensor_satellite_combo(sensor, sat_id, db_frame, satinfo):
-    dftmp = db_frame.loc[(db_frame['sat_id']==sat_id) & (db_frame['sensor']==sensor)]
+def select_subsensor_satellite_combo(subsensor, sat_id, db_frame, satinfo):
+    dftmp = db_frame.loc[(db_frame['sat_id']==sat_id) & (db_frame['subsensor']==subsensor)]
     f=interpolate.interp1d(satinfo.datetime.to_numpy().astype('float'),
           satinfo.status_nan.to_numpy().astype('float'),
           kind='previous')
@@ -53,6 +53,11 @@ def get_sensor(row):
     directory = row['parent_dir']
     sensor = directory.split("/")[2]
     return sensor
+
+def get_subsensor(row):
+    directory = row['parent_dir']
+    subsensor = directory.split("/")[3]
+    return subsensor
 
 def get_source_dir(row):
     directory = row['parent_dir']
@@ -84,7 +89,7 @@ db_frame['source_dir'] = db_frame.apply(get_source_dir, axis=1)
 db_frame = db_frame[(db_frame['sensor']=='amv')]
 
 #loop and plot sensors/sat_ids
-unique_sensor_sats = db_frame[['sensor', 'sat_id', 'sat_id_name']].value_counts().reset_index(name='count').sort_values(by = ['sensor', 'sat_id_name'], ascending=[False, False])
+unique_sensor_sats = db_frame[['sensor', 'subsensor', 'sat_id', 'sat_id_name']].value_counts().reset_index(name='count').sort_values(by = ['sensor', 'sat_id', 'sat_id_name'], ascending=[False, False, False])
 step=0.05
 height=step*len(unique_sensor_sats)
 
@@ -115,7 +120,7 @@ for index, row in unique_sensor_sats.iterrows():
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
 
     pandas.options.mode.chained_assignment = None
-    dftmp = select_sensor_satellite_combo(row['sensor'], row['sat_id'], db_frame, satinfo)
+    dftmp = select_subsensor_satellite_combo(row['subsensor'], row['sat_id'], db_frame, satinfo)
     pandas.options.mode.chained_assignment = 'warn'
 
     dirs = dftmp['source_dir'].unique()

--- a/src/plotting/plot_mysql_sensor_sat_amv.py
+++ b/src/plotting/plot_mysql_sensor_sat_amv.py
@@ -83,6 +83,7 @@ db_frame = pandas.concat([db_frame1, db_frame2], axis=0, ignore_index=True)
 
 db_frame['datetime'] = pandas.to_datetime(db_frame.obs_day)
 db_frame['sensor'] = db_frame.apply(get_sensor, axis=1)
+db_frame['subsensor'] = db_frame.apply(get_subsensor, axis=1)
 db_frame['source_dir'] = db_frame.apply(get_source_dir, axis=1)
 
 #select only amv rows

--- a/src/plotting/plot_mysql_sensor_sat_amv.py
+++ b/src/plotting/plot_mysql_sensor_sat_amv.py
@@ -106,7 +106,12 @@ plt.ylabel('Sensor & Satellite')
 directory_labels = []
 counter=0
 for index, row in unique_sensor_sats.iterrows():
-    satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    try:
+        satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    except KeyError as err:
+        print(f'unable to get satinfo string for row: {row}')
+        print(f'Error: {err}')
+        satinfo_string_ = row['sensor']
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
 
     pandas.options.mode.chained_assignment = None

--- a/src/plotting/plot_mysql_sensor_sat_geo.py
+++ b/src/plotting/plot_mysql_sensor_sat_geo.py
@@ -114,9 +114,14 @@ directory_labels=[]
 counter=0
 # for index, row in unique_sat_id.iterrows():
 for index, row in unique_sensor_sats.iterrows():
-    satinfo_string_ = row['subsensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    try:
+        satinfo_string_ = row['subsensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    except KeyError as err:
+        print(f'unable to get satinfo string for row: {row}')
+        print(f'Error: {err}')
+        satinfo_string_ = row['subsensor']
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
-
+        
     pandas.options.mode.chained_assignment = None
     dftmp = select_subsensor_satellite_combo(row['subsensor'], row['sat_id'], db_frame, satinfo)
     pandas.options.mode.chained_assignment = 'warn'

--- a/src/plotting/plot_mysql_sensor_sat_gps.py
+++ b/src/plotting/plot_mysql_sensor_sat_gps.py
@@ -107,7 +107,12 @@ directory_labels = []
 counter=0
 # for index, row in unique_sat_id.iterrows():
 for index, row in unique_sensor_sats.iterrows():
-    satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    try:
+        satinfo_string_ = row['sensor']+"_"+ utils.sat_dictionary[row['sat_id_name']]
+    except KeyError as err:
+        print(f'unable to get satinfo string for row: {row}')
+        print(f'Error: {err}')
+        satinfo_string_ = row['sensor']
     satinfo = utils.read_satinfo_files(satinfo_db_root,satinfo_string_)
 
     pandas.options.mode.chained_assignment = None

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -20,7 +20,7 @@ sat_dictionary={"NOAA 5": "n05", "NOAA 6": "n06", "NOAA 7": "n07", "NOAA 8": "n0
                "METOP-1 (Metop-B":"metop-b","METOP-2 (Metop-A":"metop-a",
                "AQUA":"aqua", "NPP":"npp",
                "GOES 7" : "g07", "GOES 8": "g08", "GOES 9": "g09", "GOES 10": "g10","GOES 11": "g11","GOES 12": "g12",
-               "GOES 13": "g13", "GOES 14": "g14", "GOES 15": "g15", "GOES 16" : "g16", "GOES 17":"g17",
+               "GOES 13": "g13", "GOES 14": "g14", "GOES 15": "g15", "GOES 16" : "g16", "GOES 17":"g17", "GOES 18":"g18",
                "MTSAT-2":"MTSAT-2", "MTSAT-1R":"MTSAT-1R",
                "METEOSAT 2" : "m02", "METEOSAT 3": "m03", "METEOSAT 4": "m04","METEOSAT 5": "m05", "METEOSAT 6": "m06", "METEOSAT 7": "m07",
                "METEOSAT 8": "m08", "METEOSAT 9": "m09", "METEOSAT 10": "m10", "METEOSAT 11": "m11",

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -39,7 +39,7 @@ sat_dictionary={"NOAA 5": "n05", "NOAA 6": "n06", "NOAA 7": "n07", "NOAA 8": "n0
                 "TanDEM-X": "TanDEM-X", "PAZ":"PAZ", "KOMPSAT-5": "KOMPSAT-5",
                "LANDSAT 5":"LANDSAT 5", "GPM-core":"GPM-core", "TRMM":"TRMM",
                "Himawari-8":"himawari8", "Himawari-9":"himawari9", "Spire Lemur 3U C":"Spire L3UC", "Sentinel 6A":"Sentinel 6A",
-               "PlanetiQ GNOMES-":"PlanetiQ GNOMES"}
+               "PlanetiQ GNOMES-":"PlanetiQ GNOMES", "AURA":"AURA"}
 
 #Dictionary for translating typ numbers from cmpbqm output into their full names
 typ_dictionary = {
@@ -96,5 +96,4 @@ def read_satinfo_files(satinfo_db_root,satinfo_string):
     #make sure the end of the series is in the future
     satinfo.loc[len(satinfo.index)]=[date(2100,1,1), satinfo.status.iat[-1], satinfo.status_nan.iat[-1]]    
     satinfo.datetime = pandas.to_datetime(satinfo.datetime)
-    display(satinfo)
     return satinfo


### PR DESCRIPTION
This PR addresses notes that were identified in NOAA NASA monthly meeting for missing data from AMV, GEO, and SEVIRI and related changes/improvements for the debugging process. 

Changes include: 
- updating atm dictionaries to include additional bufr/prepbufr files which can be inventoried (including the missing amv and geo folders)
- new capability to specify individual dictionaries at runtime with new list option for category (tested with new values) 
- split amv plot by subsensor to split up merged and satwnd by line 
- clean up line on main plot to just have sensor and sat (subsensor is on folder section) for readability 
- ability to specify work directory for nceplibs calls at command line (allows improved speed for runs since we can download files to lustre instead of contrib) 
- edited scripts to not fail if a satellite name doesn't exist in our dictionary and instead print error message -- this is key to our ability to run the scripts consistently with new satellites getting added to our dataset. if a satellite isn't in the list, it will only related to our ability to match satinfo files
- fixed date string issue which prevented help info showing for -h --help flags for arg help descriptions
- removed superfluous info statements which printed excessive amounts of data to improve speed and allow for easier identification of actual error print outs 