### PR TITLE
Unique constraint feature

### DIFF
--- a/src/automation/atm_dicts.py
+++ b/src/automation/atm_dicts.py
@@ -369,7 +369,7 @@ ozone_cfsr = InventoryInfo(
 
 ozone_nasa_sbuv_v87 = InventoryInfo(
     obs_name='ozone_nasa_sbuv_v87',
-    key='observations/reanalysis/ozone/nasa/sbuv_v87/%Y/%m/bufr/sbuv_v87.%Y%m%d.t%Hz.bufr',
+    key='observations/reanalysis/ozone/nasa/sbuv_v87/%Y/%m/bufr/sbuv_v87.%Y%m%d.%Hz.bufr',
     start='19991015T000000Z',
     s3_prefix='observations/reanalysis/ozone/nasa/sbuv_v87/%Y/%m/bufr/', 
     bufr_files='sbuv_v87.%z.bufr',

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -451,11 +451,15 @@ def insert_obs_inv_items(obs_inv_items):
         )
         rows.append(tbl_item)
 
-    #my sql version
     statement = insert(ObsInventory).values(rows)
-    statement = statement.on_duplicate_key_update(
-        valid_at=statement.inserted.valid_at
-    )
+
+    #handle the best way available for each database type
+    if(database_type.lower() == 'mysql'):
+        statement = statement.on_duplicate_key_update(
+            valid_at=statement.inserted.valid_at
+        )
+    else:
+        statement = statement.prefix_with("OR REPLACE")
 
     session = Session()
     session.execute(statement)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -425,31 +425,31 @@ def insert_obs_inv_items(obs_inv_items):
     for obs_item in obs_inv_items:
         if not isinstance(obs_item, se.TarballFileMeta):
             msg = 'Each observation inventory item must be in the form' \
-                  f' of TarballFileMeta. Item type: {type(obs_item)}'
+                f' of TarballFileMeta. Item type: {type(obs_item)}'
             raise TypeError(msg)
 
-        tbl_item = ObsInventory(
-            cmd_result_id=obs_item.cmd_result_id,
-            filename=obs_item.filename,
-            parent_dir=obs_item.parent_dir,
-            platform=obs_item.platform,
-            s3_bucket=obs_item.s3_bucket,
-            prefix=obs_item.prefix,
-            cycle_tag=obs_item.cycle_tag,
-            data_type=obs_item.data_type,
-            cycle_time=obs_item.cycle_time,
-            obs_day=obs_item.obs_day,
-            data_format=obs_item.data_format,
-            suffix=obs_item.suffix,
-            nr_tag=obs_item.nr_tag,
-            file_size=obs_item.file_size,
-            etag=obs_item.etag,
-            permissions=obs_item.permissions,
-            last_modified=obs_item.last_modified,
-            inserted_at=obs_item.inserted_at,
-            valid_at=obs_item.valid_at,
-        )
-        rows.append(tbl_item)
+        row = {
+            'cmd_result_id': obs_item.cmd_result_id,
+            'filename': obs_item.filename,
+            'parent_dir': obs_item.parent_dir,
+            'platform': obs_item.platform,
+            's3_bucket': obs_item.s3_bucket,
+            'prefix': obs_item.prefix,
+            'cycle_tag': obs_item.cycle_tag,
+            'data_type': obs_item.data_type,
+            'cycle_time': obs_item.cycle_time,
+            'obs_day': obs_item.obs_day,
+            'data_format': obs_item.data_format,
+            'suffix': obs_item.suffix,
+            'nr_tag': obs_item.nr_tag,
+            'file_size': obs_item.file_size,
+            'etag': obs_item.etag,
+            'permissions': obs_item.permissions,
+            'last_modified': obs_item.last_modified,
+            'inserted_at': obs_item.inserted_at,
+            'valid_at': obs_item.valid_at,
+        }
+        rows.append(row)
 
     statement = insert(ObsInventory).values(rows)
 

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -451,6 +451,7 @@ def insert_obs_inv_items(obs_inv_items):
         )
         rows.append(tbl_item)
 
+    #my sql version
     statement = insert(ObsInventory).values(rows)
     statement = statement.on_duplicate_key_update(
         valid_at=statement.inserted.valid_at

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -570,7 +570,7 @@ def insert_obs_meta_nceplibs_bufr_item(obs_meta_items):
                 'sat_inst_desc': item.sat_inst_desc,
                 'filename': item.filename,
                 'file_size': item.file_size,
-                'obs_day': item.obs_day,
+                'obs_day': item.obs_day.strftime('%Y-%m-%d %H:%M:%S'),
                 'inserted_at': datetime.utcnow()
             }
         rows.append(row)
@@ -625,7 +625,7 @@ def insert_obs_meta_nceplibs_prepbufr_item(obs_meta_items):
             'ckb': item.ckb,
             'filename': item.filename,
             'file_size': item.file_size,
-            'obs_day': item.obs_day,
+            'obs_day': item.obs_day.strftime('%Y-%m-%d %H:%M:%S'),
             'inserted_at': datetime.utcnow()
         }
         rows.append(row)
@@ -677,7 +677,7 @@ def insert_obs_meta_nceplibs_prepbufr_agg_item(obs_meta_items):
             'ckb': item.ckb,
             'filename': item.filename,
             'file_size': item.file_size,
-            'obs_day': item.obs_day,
+            'obs_day': item.obs_day.strftime('%Y-%m-%d %H:%M:%S'),
             'inserted_at': datetime.utcnow()
         }
         rows.append(row)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -506,11 +506,8 @@ def insert_obs_inv_items(obs_inv_items):
         #sqlite specific
         statement = sqlite_insert(ObsInventory).values(rows)
         statement = statement.on_conflict_do_update(
-            index_elements=['filename',
+            index_elements=['unique_hash',
             'obs_day',
-            'platform',
-            's3_bucket',
-            'parent_dir',
             'file_size',
             'last_modified',
             'etag'],

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -1,12 +1,12 @@
 import os
 import sqlalchemy as db
 from datetime import datetime
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 from obs_inv_utils import search_engine as se
-from sqlalchemy import Table, Column, MetaData, insert, text
+from sqlalchemy import Table, Column, MetaData, text
 from sqlalchemy import Integer, String, ForeignKey, Boolean, DateTime, Float
 from sqlalchemy import inspect, UniqueConstraint
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.dialects.mysql import insert as mysql_insert

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -9,6 +9,8 @@ from sqlalchemy import inspect, UniqueConstraint
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -489,15 +491,15 @@ def insert_obs_inv_items(obs_inv_items):
         }
         rows.append(row)
 
-    statement = insert(ObsInventory).values(rows)
-
     #handle the best way available for each database type
     if(database_type.lower() == 'mysql'):
+        statement = mysql_insert(ObsInventory).values(rows)
         statement = statement.on_duplicate_key_update(
             valid_at=statement.inserted.valid_at
         )
     else:
         #sqlite specific
+        statement = sqlite_insert(ObsInventory).values(rows)
         statement = statement.on_conflict_do_update(
             index_elements=['filename',
             'obs_day',

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -446,6 +446,7 @@ def insert_obs_inv_items(obs_inv_items):
             permissions=obs_item.permissions,
             last_modified=obs_item.last_modified,
             inserted_at=obs_item.inserted_at,
+            valid_at=obs_item.valid_at,
         )
         rows.append(tbl_item)
 

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -315,7 +315,7 @@ class ObsMetaNceplibsBufr(Base):
             'sat_id',
             'sat_inst_id',
             name='unique_bufr_meta'
-        )
+        ),
     )
 
     meta_id = Column(Integer, primary_key=True)
@@ -347,7 +347,7 @@ class ObsMetaNceplibsPrepbufr(Base):
             'typ',
             'tot',
             name='unqiue_prepbufr_meta'
-        )
+        ),
     )
 
     meta_id = Column(Integer, primary_key=True)
@@ -387,7 +387,7 @@ class ObsMetaNceplibsPrepbufrAggregate(Base):
             'file_size',
             'obs_day',
             name='unique_prebufr_agg_meta'
-        )
+        ),
     )
 
     meta_id = Column(Integer, primary_key=True)

--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -55,6 +55,7 @@ TarballFileMeta = namedtuple(
         'submitted_at',
         'latency',
         'inserted_at',
+        'valid_at',
         'etag'
     ],
 )
@@ -244,6 +245,7 @@ def process_aws_s3_list_objects_v2_resp(cmd_result_id, contents):
             contents.submitted_at,
             contents.latency,
             datetime.utcnow(),
+            datetime.utcnow(),
             listed_object.etag
         )
         files_meta.append(file_meta)
@@ -286,6 +288,7 @@ def process_aws_s3_clean_resp(cmd_result_id, contents):
             contents.submitted_at,
             contents.latency,
             datetime.utcnow(),
+            datetime.utcnow(),
             listed_object.etag
     ))
 
@@ -325,6 +328,7 @@ def process_inspect_tarball_resp(cmd_result_id, contents):
             inspected_file.last_modified,
             contents.submitted_at,
             contents.latency,
+            datetime.utcnow(),
             datetime.utcnow(),
             ''
         )


### PR DESCRIPTION
This PR addresses a need to enforce uniqueness on the obs inventory and meta data tables to prevent overloading the database with duplicated data. This should improve our database performance and maintainability. It maintains the capability to use either MySQL or sqlite. 

The specific changes are applying a unique constraint and checking when inserting to enforce the constraint. For the obs inventory table, if there is a conflict then it will update the valid_at field to keep track of the last time the file was confirmed in the inventory to be the same. The constraint specifics the exact file location, name, last modified date, and meta data such as file size and etag. In the case that a file is changed in the inventory, a new entry to the obs inventory table will be made. 

Both MySQL via the test database and the sqlite capabilities have been tested and verified to no longer have duplicates and appropriately update the obs inventory table's new valid_at column. 


