### PR TITLE
maintenance update: switch to using invdisk

### DIFF
--- a/obs_inv_utils_pw_inv_cluster.sh
+++ b/obs_inv_utils_pw_inv_cluster.sh
@@ -6,7 +6,7 @@ conda activate obs-inventory-env
 module load gnu
 module load intel/2023.2.0
 module load impi/2023.2.0
-export PATH=/contrib/inv-stack/ncep/NCEPLIBS-bufr-12.1.0/build/utils:$PATH 
+export PATH=/invdisk/nceplibs-stack/ncep/NCEPLIBS-bufr-12.1.0/build/utils:$PATH 
 
 OBS_INV_HOME_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export PYTHONPATH=$OBS_INV_HOME_DIR/src

--- a/src/automation/run_16day_inventory.sh
+++ b/src/automation/run_16day_inventory.sh
@@ -6,7 +6,7 @@
 SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
 OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
-WORK_DIR=/lustre/home/work/inventory-work
+WORK_DIR=/invdisk/inventory-work
 
 cd $(dirname $0)
 

--- a/src/automation/run_32day_inventory.sh
+++ b/src/automation/run_32day_inventory.sh
@@ -6,7 +6,7 @@
 SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
 OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
-WORK_DIR=/lustre/home/work/inventory-work
+WORK_DIR=/invdisk/inventory-work
 
 cd $(dirname $0)
 

--- a/src/automation/run_3day_inventory.sh
+++ b/src/automation/run_3day_inventory.sh
@@ -6,7 +6,7 @@
 SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
 OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
-WORK_DIR=/lustre/home/work/inventory-work
+WORK_DIR=/invdisk/inventory-work
 
 cd $(dirname $0)
 

--- a/src/automation/run_full_inventory.sh
+++ b/src/automation/run_full_inventory.sh
@@ -5,7 +5,7 @@
 SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
 OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
-WORK_DIR=/lustre/home/work/inventory-work
+WORK_DIR=/invdisk/inventory-work
 
 cd $(dirname $0)
 

--- a/src/automation/run_plots_only.sh
+++ b/src/automation/run_plots_only.sh
@@ -4,7 +4,7 @@
 SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
 OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
-WORK_DIR=/lustre/home/work/inventory-work
+WORK_DIR=/invdisk/inventory-work
 
 cd $(dirname $0)
 


### PR DESCRIPTION
This PR makes the necessary maintenance changes for the automation scripts and obs_inv_utils_pw_inv_cluster.sh script to operate using the new invdisk on the clusters 