### PR TITLE
Maintenance -- print less output

### DIFF
--- a/src/automation/auto_inventory.py
+++ b/src/automation/auto_inventory.py
@@ -81,11 +81,11 @@ import obs_inv_utils.obs_inv_cli as cli
 def get_start_end_time(inventory_info):
     #additional cycling options will need to be added as functionality expands 
     if inventory_info.cycling_interval == au.CYCLING_6H:
-        frequency = '6H'
+        frequency = '6h'
     elif inventory_info.cycling_interval == au.CYCLING_HOURLY:
-        frequency = 'H'
+        frequency = 'h'
     else: #default to round to closest hour
-        frequency = 'H'
+        frequency = 'h'
 
     if end_date != None:
         end = Timestamp(end_date).round(freq=frequency)

--- a/src/config_handlers/obs_meta_cmpbqm.py
+++ b/src/config_handlers/obs_meta_cmpbqm.py
@@ -44,9 +44,6 @@ class ObsMetaCMPBQMConfig(ConfigInterface):
         self.parse()
 
     def parse(self):
-        print(f'type(self.config_data): {type(self.config_data)}')
-        
-
         self.s3_bucket = self.yaml_loader.get_value(
             key='s3_bucket',
             document=self.config_data,

--- a/src/config_handlers/obs_meta_sinv.py
+++ b/src/config_handlers/obs_meta_sinv.py
@@ -44,9 +44,6 @@ class ObsMetaSinvConfig(ConfigInterface):
         self.parse()
 
     def parse(self):
-        print(f'type(self.config_data): {type(self.config_data)}')
-        
-
         self.s3_bucket = self.yaml_loader.get_value(
             key='s3_bucket',
             document=self.config_data,

--- a/src/config_handlers/obs_search_conf.py
+++ b/src/config_handlers/obs_search_conf.py
@@ -53,7 +53,6 @@ class ObsSearchConfig(object):
         path = time_utils.get_datetime_str(
             current, self.search_config.get(SEARCH_PATH_KEY)
         )
-        print(f'path: {path}')
         return path
 
 
@@ -76,7 +75,6 @@ class ObservationsConfig(ConfigInterface):
     def load(self):
         self.config_data = self.yaml_loader.load()
         self.parse()
-        print(f'config_data: {self.config_data}')
 
     def parse(self):
         
@@ -102,12 +100,8 @@ class ObservationsConfig(ConfigInterface):
         self.search_date_range = time_utils.get_date_range_from_dict(
             config_date_range)
 
-        print(f'search_date_range: {self.search_date_range}')
-
         try:
             for obs_search_config in obs_search_configs:
-                print(f'obs_search_config: {obs_search_config}')
-
                 storage_platform = self.yaml_loader.get_value(
                     key='platform',
                     document=obs_search_config,
@@ -127,7 +121,6 @@ class ObservationsConfig(ConfigInterface):
                 )
                 search_key = obs_search_config['key']
                 hash_key = f'{storage_platform}-{search_key}'
-                print(f'hash_key: {hash_key}')
                 self.obs_search_configs[hash_key] = obs_search_config_obj
 
         except Exception as e:

--- a/src/obs_inv_utils/aws_s3_interface.py
+++ b/src/obs_inv_utils/aws_s3_interface.py
@@ -89,10 +89,6 @@ def download_s3_object(
         dest_full_path=None,
         expected_size=None
 ):
-    print(f'client: {client}, bucket: {bucket}, s3_object_key: ' \
-        f'{s3_object_key}, dest_full_path: {dest_full_path}, ' \
-        f'expected_size: {expected_size}')
-
     # remove file if it exists
     try:
         if os.path.exists(dest_full_path):
@@ -135,7 +131,7 @@ def download_s3_object(
         'success': (statusCode == 200),
         'message': msg
     }
-    print(f'response: {response}')
+    print(f'S3 download response metadata: {response}')
 
     return response
 
@@ -174,7 +170,6 @@ def get_objects_list_args_valid(args):
 
 
 def download_s3_obj_args_valid(args):
-    print(f'inside download_s3_obj_args_valid - args: {args}')
     return {
         'bucket': AWS_BDP_BUCKET,
         's3_object_key': args[0],
@@ -184,7 +179,6 @@ def download_s3_obj_args_valid(args):
 
 
 def download_s3_obj_resp_parser(response, obs_cycle_time):
-    print(f'inside download_s3_obj_resp_parser - response: {response}')
     return None
 
 
@@ -194,10 +188,7 @@ def s3_object_list_v2_parser(obj_list_contents, obs_cycle_time):
               f'Received type: {type(obj_list_contents)}'
         raise TypeError(msg)
 
-    # print(f'obs_cycle_time: {obs_cycle_time}, contents: {obj_list_contents}')
-
     object_list = obj_list_contents.output.get('Contents')
-    # print(f'object_list: {object_list}')
 
     files_meta = list()
     prefix = obj_list_contents.args_0
@@ -205,19 +196,15 @@ def s3_object_list_v2_parser(obj_list_contents, obs_cycle_time):
     file_count = len(object_list)
 
     for object_item in object_list:
-        print(f'object_item: {object_item}')
-
         size = object_item.get('Size')
         last_modified = object_item.get('LastModified')
         fn_str = object_item.get('Key')
         etag = object_item.get('ETag')[1:-1]
         fn = fn_str[len(prefix):]
         
-        print(f'fn: {fn}')
         files_meta.append(
             AwsS3FileMeta(fn, permissions, last_modified, size, etag))
 
-    # print(f'files_meta: {files_meta}')
     return AwsS3ObjectsListContents(
         prefix,
         file_count,
@@ -243,7 +230,6 @@ aws_s3_cmds = {
 
 
 def is_valid_aws_s3_cmd(instance, attribute, value):
-    print(f'In is_valid_aws_s3_cmd: value: {value}')
     if value not in aws_s3_cmds:
         msg = f'AWS s3 command {value} is not valid. Use one of: ' \
               f'{aws_s3_cmds.keys()}'
@@ -265,12 +251,10 @@ class AwsS3CommandHandler(object):
 
     def __attrs_post_init__(self):
         self.cmd_obj = aws_s3_cmds[self.command]
-        print(f'In __attrs_post_init__: self.args: {self.args}')
         # it will blow up here if the arguments are invalid
         self.kwargs = self.cmd_obj.arg_validator(self.args)
 
         self.client = get_bdp_s3_client()
-        print(f'kwargs: {self.kwargs}')
 
 
     def send(self):
@@ -281,14 +265,10 @@ class AwsS3CommandHandler(object):
         except Exception as e:
             msg = f'Error after sending command {self.command}, error: {e}.'
             raise ValueError(msg)
-        response_type = type(response)
-        print(f'type(response): {response_type}, response: {response}')
         resp_meta = response.get('ResponseMetadata')
-        # print(f'resp_meta: {resp_meta}')
         self.raw_resp = response
         returncode = 404
         contents = response.get('Contents')
-        # print(f'contents: {contents}')
         if resp_meta is not None:
             returncode = resp_meta.get('HTTPStatusCode')
             if contents is None:
@@ -303,8 +283,6 @@ class AwsS3CommandHandler(object):
             self.submitted_at,
             float(self.get_cmd_duration())
         )
-
-        print(f'raw_resp: {self.raw_resp}')
 
         return (returncode == 200)
 

--- a/src/obs_inv_utils/aws_s3_interface.py
+++ b/src/obs_inv_utils/aws_s3_interface.py
@@ -150,7 +150,6 @@ def get_objects_list_args_valid(args):
         msg = f'Args must be in the form of a list, args: {args}'
         raise TypeError(msg)
     cmd = aws_s3_cmds[CMD_GET_S3_OBJ_LIST].command
-    print(f'{nl}{nl}In inspect tarball args valid: cmd: {cmd}{nl}{nl}')
     if (len(args) > 1 or len(args) == 0):
         msg = f'Command "{cmd}" accepts exactly 1 argument, received ' \
               f'{len(args)}.'

--- a/src/obs_inv_utils/file_utils.py
+++ b/src/obs_inv_utils/file_utils.py
@@ -27,7 +27,6 @@ def is_valid_readable_file(filepath):
 
     # check permissions on file
     status = os.stat(filepath, follow_symlinks=True)
-    print(f'status.st_size: {status.st_size}')
     if status.st_size == 0:
         print(f'if block caught 0 byte file {status}')
         raise ValueError(f'Invalid file. File {filepath} is empty.')

--- a/src/obs_inv_utils/hpss_io_interface.py
+++ b/src/obs_inv_utils/hpss_io_interface.py
@@ -139,7 +139,6 @@ hpss_cmds = {
 
 
 def is_valid_hpss_cmd(instance, attribute, value):
-    print(f'In is_valid_hpss_cmd: value: {value}')
     if value not in hpss_cmds:
         msg = f'HPSS command {value} is not valid. Use one of: ' \
               f'{hpss_cmds.keys()}'
@@ -160,13 +159,10 @@ class HpssCommandHandler(object):
 
     def __attrs_post_init__(self):
         self.cmd_obj = hpss_cmds[self.command]
-        print(f'In __attrs_post_init__: self.args: {self.args}')
         if self.cmd_obj.arg_validator(self.args):
             self.cmd_line = getattr(self.cmd_obj,'command').copy()
             for arg in self.args:
                 self.cmd_line.append(arg)
-        print(f'cmd_line: {self.cmd_line}, args: {self.args}')
-
 
     def send(self):
         cmd_str = self.cmd_obj.command[0]
@@ -181,7 +177,6 @@ class HpssCommandHandler(object):
             self.submitted_at = datetime.now(timezone.utc)
             out, err = proc.communicate()
             self.finished_at = datetime.now(timezone.utc)
-            print(f'return_code: {proc.returncode}, out: {out}, err: {err}')
         except FileNotFoundError as e:
             msg = f'Command: {cmd_str} was not recognized. '\
                   f'error: {e}{nl}{nl}' \
@@ -204,8 +199,6 @@ class HpssCommandHandler(object):
             self.submitted_at,
             float(self.get_cmd_duration())
         )
-
-        print(f'raw_resp: {self.raw_resp}')
         
         if proc.returncode != 0:
             return False

--- a/src/obs_inv_utils/hpss_io_interface.py
+++ b/src/obs_inv_utils/hpss_io_interface.py
@@ -61,7 +61,6 @@ def inspect_tarball_args_valid(args):
         msg = f'Args must be in the form of a list, args: {args}'
         raise TypeError(msg)
     cmd = hpss_cmds[CMD_INSPECT_TARBALL].command
-    print(f'{nl}{nl}In inspect tarball args valid: cmd: {cmd}{nl}{nl}')
     if (len(args) > 1 or len(args) == 0):
         msg = f'Command "{cmd}" accepts exactly 1 argument, received ' \
               f'{len(args)}.'
@@ -95,7 +94,6 @@ def inspect_tarball_parser(response, obs_day):
     parent_dir = ''
     files_meta = list()
     for output_line in output:
-        print(f'out_line: {output_line}')
         components = output_line.split()
         if len(components) < EXPECTED_COMPONENTS_HTAR_TVF_FILE_OBJ:
             continue

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -721,7 +721,6 @@ def insert_cmd_result(cmd_result_data):
     session = Session()
     session.add(tbl_item)
     session.commit()
-    print(f'cmd_result id: {tbl_item.cmd_result_id}')
     cmd_id = tbl_item.cmd_result_id
     session.close()
     return cmd_id

--- a/src/obs_inv_utils/nceplibs_bufr_cmd_handler.py
+++ b/src/obs_inv_utils/nceplibs_bufr_cmd_handler.py
@@ -68,14 +68,11 @@ def download_bufr_file_from_s3(work_dir, bufr_file):
 
     dest_filename = os.path.join(dest_path, bufr_file['filename'])
     
-    print(f'dest_filename: {dest_filename}')
-
     # setup command arguments, [file s3 key, destination location,
     # and expected filesize
     args = [object_key, dest_filename, bufr_file['file_size']]
 
     cmd = s3.AwsS3CommandHandler(s3.CMD_DOWNLOAD_S3_OBJ, args)
-    print(f'cmd: {cmd}')
 
     saved_filename = None
     if cmd.send():
@@ -83,9 +80,7 @@ def download_bufr_file_from_s3(work_dir, bufr_file):
 
     # post result from command success or failure
     raw_resp = cmd.get_raw_response()
-    print(f'raw_resp')
 
-    print('posting command results for aws s3')
     post_aws_s3_cmd_result(
         raw_resp,
         bufr_file['obs_day']
@@ -125,12 +120,8 @@ class ObsBufrFileMetaHandler(object):
 
         work_dir = os.path.join(self.meta_config.work_dir, temp_uuid)
 
-        print(f'inventory_bufr_files: {inventory_bufr_files}')
-        print(f'scrub_files: {self.meta_config.scrub_files}')
         for idx, bufr_file in inventory_bufr_files.iterrows():
             file_downloaded = False
-            print(
-               f'bufr_file: {bufr_file}')
 
             saved_filename = download_bufr_file_from_s3(work_dir, bufr_file)
 
@@ -152,7 +143,6 @@ class ObsBufrFileMetaHandler(object):
             nc_cmds.nceplibs_cmds,
             args
         )
-        print(f'cmd: {cmd}')
 
         if not cmd.send():
             return False
@@ -160,9 +150,6 @@ class ObsBufrFileMetaHandler(object):
         cmd.post_cmd_result(bufr_file.obs_day)
 
         sinv_lines_meta = cmd.parse_output(bufr_file)
-        for meta in sinv_lines_meta:
-            print(f'meta: {meta}')
-
     
         cmd.post_parsed_result(sinv_lines_meta, bufr_file)
         
@@ -196,13 +183,7 @@ class ObsPrepBufrFileMetaHandler(object):
         temp_uuid = str(uuid.uuid4())
 
         work_dir = os.path.join(self.meta_config.work_dir, temp_uuid)
-
-        print(f'inventory_prepbufr_files: {inventory_prepbufr_files}')
-        print(f'scrub_files: {self.meta_config.scrub_files}')
         for idx, prepbufr_file in inventory_prepbufr_files.iterrows():
-            print(
-               f'bufr_file: {prepbufr_file}')
-
             saved_filename = download_bufr_file_from_s3(work_dir, prepbufr_file)
 
             if saved_filename is None:
@@ -221,7 +202,6 @@ class ObsPrepBufrFileMetaHandler(object):
             nc_cmds.nceplibs_cmds,
             args
         )
-        print(f'cmd: {cmd}')
 
         if not cmd.send():
             return False
@@ -229,7 +209,5 @@ class ObsPrepBufrFileMetaHandler(object):
         cmd.post_cmd_result(prepbufr_file.obs_day)
 
         cmpbqm_lines_meta = cmd.parse_output(prepbufr_file)
-        for meta in cmpbqm_lines_meta:
-            print(f'meta: {meta}')
         
         cmd.post_parsed_result(cmpbqm_lines_meta, prepbufr_file)

--- a/src/obs_inv_utils/nceplibs_cmd_cmpbqm.py
+++ b/src/obs_inv_utils/nceplibs_cmd_cmpbqm.py
@@ -104,7 +104,7 @@ def parse_output(output, prepbufr_file):
                 break
 
             # skip lines which are all ----
-            if cleaned_line[0] is '-':
+            if cleaned_line[0] == '-':
                 continue
 
             #skip lines with 'DATA' in it since this is just a header

--- a/src/obs_inv_utils/nceplibs_cmd_cmpbqm.py
+++ b/src/obs_inv_utils/nceplibs_cmd_cmpbqm.py
@@ -263,4 +263,3 @@ def post_obs_meta_data(cmd_id, lines_meta, prepbufr_file):
     #insert items into appropriate tables
     itf.insert_obs_meta_nceplibs_prepbufr_item(obs_meta_data_items)
     itf.insert_obs_meta_nceplibs_prepbufr_agg_item(obs_meta_data_agg_items)
-    print("data file items inserted to database")

--- a/src/obs_inv_utils/nceplibs_cmd_sinv.py
+++ b/src/obs_inv_utils/nceplibs_cmd_sinv.py
@@ -88,10 +88,8 @@ def get_line_type(line):
     return FILLER_LINE
   
 def parse_output(output, bufr_file):
-    print(f"output: {output}")
     # split the output into an array of lines
     output_lines = output.split('\n')
-    print(f'output_lines: {output_lines}')
     lines_meta = []
     obs_cnt_sum = 0
     for line in output_lines:

--- a/src/obs_inv_utils/obs_inv_cli.py
+++ b/src/obs_inv_utils/obs_inv_cli.py
@@ -58,14 +58,12 @@ def plot_files_filesize_vs_time(min_instances):
 def plot_groups_filesize_timeseries(config_yaml):
     config = ObsGroupFileSizePlotConfig(config_yaml)
     config.load()
-    # print(repr(config))
     obgr = pg.ObsGroupFilesizeTimeline(config)
     obgr.plot_obsgroups_fs_timeline()
 
 def get_obs_count_meta_sinv_base(config_yaml):
     config = ObsMetaSinvConfig(config_yaml)
     config.load()
-    print(repr(config))
     mh = ObsBufrFileMetaHandler(config)
     mh.get_bufr_file_meta(obs_meta_sinv.NCEPLIBS_BUFR_SINV)
 
@@ -77,7 +75,6 @@ def get_obs_count_meta_sinv(config_yaml):
 def get_obs_count_meta_cmpbqm_base(config_yaml):
     config = ObsMetaCMPBQMConfig(config_yaml)
     config.load()
-    print(repr(config))
     mh = ObsPrepBufrFileMetaHandler(config)
     mh.get_prepbufr_file_meta(obs_meta_cmpbqm.NCEPLIBS_PREPBUFR_CMPBQM)
 
@@ -89,7 +86,6 @@ def get_obs_count_meta_cmpbqm(config_yaml):
 def get_obs_count_meta_ioda_hv_base(config_yaml):
     config = ObsMetaIodaConfig(config_yaml)
     config.load()
-    print(repr(config))
     mh = ObsIodaFileMetaHandler(config)
     mh.get_ioda_file_meta(obs_meta_ioda.HV_IODA_META)
 

--- a/src/obs_inv_utils/obs_inv_queries.py
+++ b/src/obs_inv_utils/obs_inv_queries.py
@@ -185,5 +185,8 @@ def get_files_data(filenames, start, end):
     ).all()
 
     df = DataFrame(fn_fs)
-    #should we print if this is empty??? 
+    
+    if df.empty:
+        print(f'NO FILES TO GET: DataFrame is empty.\n Filenames: {filenames} \n Start: {start} End: {end}')
+    
     return df

--- a/src/obs_inv_utils/obs_inv_queries.py
+++ b/src/obs_inv_utils/obs_inv_queries.py
@@ -30,8 +30,6 @@ def get_family_fs_data(obs_family):
 
     session = Session()
     oi = itf.ObsInventory
-    print(
-        f'Here in sql query - table_exists: {table_exists}, obs_family: {obs_family}')
     filenames = set()
     members = obs_family.get_members()
     for member in members:
@@ -94,8 +92,6 @@ def get_filesize_timeline_data(min_instances):
         'un'
     ).subquery()
 
-    print(f'subquery unique_names: {unique_names}')
-
     fn_fs = session.query(
         oi.prefix,
         oi.filename,
@@ -151,8 +147,6 @@ def get_files_data(filenames, start, end):
     session = Session()
     oi = itf.ObsInventory
 
-    print(
-        f'Here in sql query - bufr_filenames: {filenames}, {start}, {end}')
     unique_filenames = set()
     for filename in filenames:
         unique_filenames.add(filename)
@@ -190,10 +184,6 @@ def get_files_data(filenames, start, end):
         oi.filename
     ).all()
 
-    print(f'fn_fs: {fn_fs}')
-
     df = DataFrame(fn_fs)
-
-    print(f'df: {df}')
-
+    #should we print if this is empty??? 
     return df

--- a/src/obs_inv_utils/plot_generator.py
+++ b/src/obs_inv_utils/plot_generator.py
@@ -26,7 +26,7 @@ OBS_INV_DATERANGE = pd.date_range(
 OBS_INV_DATERANGE_6H_CYCLE = pd.date_range(
     DEFAULT_MIN_DATETIME,
     DEFAULT_MAX_DATETIME,
-    freq='6H'
+    freq='6h'
 )
 
 EXT_OBS_ERA5 = 'era5'

--- a/src/obs_inv_utils/score_hv_netcdf_cmd_handler.py
+++ b/src/obs_inv_utils/score_hv_netcdf_cmd_handler.py
@@ -114,8 +114,7 @@ class ObsIodaFileMetaHandler(object):
 
         for idx, ioda_file in inventory_ioda_files.iterrows():
             file_downloaded = False
-            print(f'ioda_file: {ioda_file}')
-
+            
             saved_filename = download_netcdf_file_from_s3(work_dir, ioda_file)
 
             if saved_filename is None:

--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -311,7 +311,6 @@ def process_aws_s3_list_objects_v2_resp(cmd_result_id, contents):
     listed_objects = contents.listed_objects
 
     files_meta = []
-    print(f'inside process_aws_s3_list_objects - cmd_result_id: {cmd_result_id}')
     for listed_object in listed_objects:
         fn = listed_object.name
         print(f'filename: {fn}')
@@ -319,7 +318,6 @@ def process_aws_s3_list_objects_v2_resp(cmd_result_id, contents):
         if fn_meta is None:
             print('regular expression file name did not match, reverting to default behavior')
             fn_meta = parse_filename(fn)
-        print(f'filename meta: {fn_meta}')
 
         file_meta = TarballFileMeta(
             cmd_result_id,
@@ -356,15 +354,12 @@ def process_aws_s3_clean_resp(cmd_result_id, contents):
     listed_objects = contents.listed_objects
 
     files_meta = []
-    print(f'inside process_aws_s3_list_objects - cmd_result_id: {cmd_result_id}')
-    print(f'inside process_aws_s3_list_objects - contents: {contents}')
     fn = os.path.basename(contents.prefix)
     print(f'filename: {fn}')
     fn_meta = parse_filename_regex(fn)
     if fn_meta is None: #if the regular expression didn't match, default to old behavior
         print('regular expression file name did not match, reverting to default behavior')
         fn_meta = parse_filename_clean_bucket(fn)
-    print(f'filename meta: {fn_meta}')
 
     listed_object = listed_objects[0]
     files_meta.append(TarballFileMeta(
@@ -406,7 +401,6 @@ def process_inspect_tarball_resp(cmd_result_id, contents):
         fn = inspected_file.name
         print(f'filename: {fn}')
         fn_meta = parse_filename(fn)
-        print(f'filename meta: {fn_meta}')
 
         tarball_file_meta = TarballFileMeta(
             cmd_result_id,
@@ -483,7 +477,6 @@ def post_hpss_cmd_result(raw_response, obs_day):
         datetime.now(timezone.utc)
     )
 
-    print(f'HPSS cmd_result: {cmd_result_data}')
     cmd_result_id = tbl_factory.insert_cmd_result(cmd_result_data)
 
     return cmd_result_id
@@ -502,27 +495,21 @@ class ObsInventorySearchEngine(object):
 
         date_range = self.obs_inv_conf.get_search_date_range()
         master_list = []
-        print(f'search config date range: {date_range}')
 
         all_search_paths_finished = False
         loop_count = 0
         while not all_search_paths_finished:
-            print(
-                f'loop {loop_count} of while loop, all_search_paths_finished: {all_search_paths_finished}')
             loop_count += 1
             finished_count = 0
             for key, search_config in self.search_configs.items():
-                # print(f'search_config: {search_config}')
                 search_path = search_config.get_current_search_path()
 
                 if search_config.get_date_range().at_end():
                     end = search_config.get_date_range().end
                     finished_count += 1
-                    print(f'Finished search, path: {search_path}, end: {end}')
                     continue
 
                 args = [search_path]
-                print(f'args: {args}, search_path: {search_path}')
                 platform = search_config.get_storage_platform()
                 if platform == platforms.AWS_S3 or platform == platforms.AWS_S3_CLEAN:
                     cmd = s3.AwsS3CommandHandler(s3.CMD_GET_S3_OBJ_LIST, args)
@@ -530,15 +517,11 @@ class ObsInventorySearchEngine(object):
                     cmd = hpss.HpssCommandHandler(
                         hpss.CMD_INSPECT_TARBALL, args)
   
-
-                print(f'cmd: {cmd}, finished_count: {finished_count}')
-
                 success = cmd.send()
 
                 raw_resp = cmd.get_raw_response()
 
                 if platform == platforms.AWS_S3 or platform == platforms.AWS_S3_CLEAN:
-                    print('posting command results for aws s3')
                     self.cmd_post_id = post_aws_s3_cmd_result(
                         raw_resp,
                         search_config.get_date_range().current
@@ -549,11 +532,8 @@ class ObsInventorySearchEngine(object):
                         search_config.get_date_range().current
                     )
 
-                print(f'self.cmd_post_id: {self.cmd_post_id}')
-
                 if success:
                     current_time = search_config.get_date_range().current
-                    print(f'current_time: {current_time}')
                     contents = cmd.parse_response(current_time)
 
                     if platform == platforms.AWS_S3:
@@ -578,7 +558,6 @@ class ObsInventorySearchEngine(object):
                 raw_resp = cmd.get_raw_response()
 
                 search_config.get_date_range().increment(seconds=search_config.get_cycling_interval())
-                print(f'Current search path: {search_path}')
 
             if finished_count == len(self.search_configs):
                 all_search_paths_finished = True

--- a/src/obs_inv_utils/subprocess_cmd_handler.py
+++ b/src/obs_inv_utils/subprocess_cmd_handler.py
@@ -49,13 +49,10 @@ class SubprocessCmdHandler(object):
 
     def __post_init__(self):
         self.cmd_obj = self.subprocess_cmds[self.command]
-        print(f'In __post_init__: self.args: {self.args}')
-        print(f'In __post_init__: self.cmd_obj: {self.cmd_obj}')
         if self.cmd_obj.validate_args(self.args):
             self.cmd_line = getattr(self.cmd_obj,'command').copy()
             for arg in self.args:
                 self.cmd_line.append(arg)
-        print(f'cmd_line: {self.cmd_line}, args: {self.args}')
 
 
     def send(self):
@@ -71,7 +68,6 @@ class SubprocessCmdHandler(object):
             self.submitted_at = datetime.now(timezone.utc)
             out, err = proc.communicate()
             self.finished_at = datetime.now(timezone.utc)
-            print(f'return_code: {proc.returncode}, out: {out}, err: {err}')
         except FileNotFoundError as e:
             msg = f'Command: {cmd_str} was not recognized. '\
                   f'error: {e}{nl}{nl}' \
@@ -94,8 +90,6 @@ class SubprocessCmdHandler(object):
             self.submitted_at,
             float(self.get_cmd_duration())
         )
-
-        print(f'raw_resp: {self.raw_resp}')
         
         if proc.returncode != 0:
             return False
@@ -139,7 +133,6 @@ class SubprocessCmdHandler(object):
         )
 
         self.cmd_id = tbl_factory.insert_cmd_result(cmd_result_data)
-        print(f'In subproc, cmd result id: {self.cmd_id}')
 
 
     def post_parsed_result(self, parsed_data, context):

--- a/src/obs_inv_utils/time_utils.py
+++ b/src/obs_inv_utils/time_utils.py
@@ -43,7 +43,6 @@ def is_valid_increment_type(value):
 def set_datetime(time_str, format_str):
     try:
         time = datetime.strptime(time_str, format_str)
-        print(f'in set_datetime - time: {time}, time_str: {time_str}, format_str: {format_str}')
     except Exception as e:
         msg = f'Invalid time str: {time_str} or format string: {format_str}. {e}'
         raise ValueError(msg)

--- a/src/obs_inv_utils/yaml_utils.py
+++ b/src/obs_inv_utils/yaml_utils.py
@@ -50,7 +50,7 @@ class YamlLoader(object):
         except OSError as e:
             msg = """ Please ensure the file exists and you have the required
                       access privileges."""
-            raise IOError(f"Could not open {self.yaml_file}: {e.strerror}", msg)
+            raise OSError(f"Could not open {self.yaml_file}: {e.strerror}", msg)
         except Exception as e:
             raise ValueError(f'Unkown error when parsing {self.yaml_file}, err: {e}')
         

--- a/src/obs_inv_utils/yaml_utils.py
+++ b/src/obs_inv_utils/yaml_utils.py
@@ -32,7 +32,6 @@ class YamlLoader(object):
         validator=attr.validators.instance_of(bool), default=False)
 
     def load(self):
-        print(f'multiple_docs: {self.multiple_docs}')
         try:
             print(f'loading yaml file: {self.yaml_file}')
             with open(self.yaml_file, 'r') as yaml_stream:
@@ -63,8 +62,6 @@ class YamlLoader(object):
         """Lookup a key in a nested list of documents, return all matches"""
         
         found_keys = list(self._get_nested_key(key, document))
-
-        print(f'values found: {found_keys}')
         
         if len(found_keys) > 1:
             msg = f'Key "{key}" found multiple times. Result ambiguous.'

--- a/src/obs_inv_utils/yaml_utils.py
+++ b/src/obs_inv_utils/yaml_utils.py
@@ -33,7 +33,6 @@ class YamlLoader(object):
 
     def load(self):
         try:
-            print(f'loading yaml file: {self.yaml_file}')
             with open(self.yaml_file, 'r') as yaml_stream:
                 documents = list(
                     yaml.load_all(yaml_stream, Loader=yaml.SafeLoader)
@@ -51,7 +50,7 @@ class YamlLoader(object):
         except OSError as e:
             msg = """ Please ensure the file exists and you have the required
                       access privileges."""
-            raise VergeMLError(f"Could not open {self.yaml_file}: {e.strerror}", msg)
+            raise IOError(f"Could not open {self.yaml_file}: {e.strerror}", msg)
         except Exception as e:
             raise ValueError(f'Unkown error when parsing {self.yaml_file}, err: {e}')
         

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -88,7 +88,7 @@ def read_satinfo_files(satinfo_db_root,satinfo_string):
     satinfo=pandas.DataFrame(columns=['datetime','status','status_nan'])
     for fn in glob.glob(os.path.join(satinfo_db_root,satinfo_string,'??????????')):
         pd_tmp = pandas.read_csv(os.path.join(satinfo_db_root,satinfo_string,os.path.basename(fn))
-            ,header=None,sep='\s+'
+            ,header=None,sep=r'\s+'
             ,names=['sensor','ch_num','status','error','o1','o2','o3','o4','o5','o6','o7'])
         tmp_frame=pandas.DataFrame([[datetime.strptime(os.path.basename(fn),'%Y%m%d%H'), (pd_tmp['status']>0).any()]]
             ,columns=['datetime','status'])
@@ -112,7 +112,7 @@ def read_ozinfo_files(ozinfo_db_root,ozinfo_string):
     ozinfo=pandas.DataFrame(columns=['datetime','status','status_nan'])
     for fn in glob.glob(os.path.join(ozinfo_db_root,ozinfo_string,'??????????')):
         pd_tmp = pandas.read_csv(os.path.join(ozinfo_db_root,ozinfo_string,os.path.basename(fn))
-            ,header=None,sep='\s+'
+            ,header=None,sep=r'\s+'
             ,names=['sensor','ch_num','status','pressure_level','gross_error','ob_error','b_oz','pg_oz'])
         tmp_frame=pandas.DataFrame([[datetime.strptime(os.path.basename(fn),'%Y%m%d%H'), (pd_tmp['status']>0).any()]]
             ,columns=['datetime','status'])

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -92,14 +92,15 @@ def read_satinfo_files(satinfo_db_root,satinfo_string):
             ,names=['sensor','ch_num','status','error','o1','o2','o3','o4','o5','o6','o7'])
         tmp_frame=pandas.DataFrame([[datetime.strptime(os.path.basename(fn),'%Y%m%d%H'), (pd_tmp['status']>0).any()]]
             ,columns=['datetime','status'])
-        satinfo=pandas.concat([satinfo,tmp_frame])
+        frames_to_concat = [df for df in [satinfo, tmp_frame] if not df.empty and not df.isna().all().all()]
+        satinfo = pandas.concat(frames_to_concat)
     #if empty make 
     if (satinfo.empty):
       satinfo.loc[len(satinfo.index)] = [date(1900,1,1), False, np.nan]
       satinfo.loc[len(satinfo.index)] = [date(2100,1,1), False, np.nan]
     #convert logical to floats with nans for plotting
     satinfo['status_nan'] = satinfo.status.astype('int')
-    satinfo['status_nan'].replace(0, np.nan, inplace=True)
+    satinfo['status_nan'] = satinfo['status_nan'].replace(0, np.nan)
     #make sure the end of the series is in the future
     satinfo.loc[len(satinfo.index)]=[date(2100,1,1), satinfo.status.iat[-1], satinfo.status_nan.iat[-1]]    
     satinfo.datetime = pandas.to_datetime(satinfo.datetime)
@@ -115,7 +116,8 @@ def read_ozinfo_files(ozinfo_db_root,ozinfo_string):
             ,names=['sensor','ch_num','status','pressure_level','gross_error','ob_error','b_oz','pg_oz'])
         tmp_frame=pandas.DataFrame([[datetime.strptime(os.path.basename(fn),'%Y%m%d%H'), (pd_tmp['status']>0).any()]]
             ,columns=['datetime','status'])
-        ozinfo=pandas.concat([ozinfo,tmp_frame])
+        frames_to_concat = [df for df in [ozinfo, tmp_frame] if not df.empty and not df.isna().all().all()]
+        ozinfo = pandas.concat(frames_to_concat)
     #if empty make 
     if (ozinfo.empty):
       print(f'Empty ozinfo: {ozinfo_string}')
@@ -123,7 +125,7 @@ def read_ozinfo_files(ozinfo_db_root,ozinfo_string):
       ozinfo.loc[len(ozinfo.index)] = [date(2100,1,1), False, np.nan]
     #convert logical to floats with nans for plotting
     ozinfo['status_nan'] = ozinfo.status.astype('int')
-    ozinfo['status_nan'].replace(0, np.nan, inplace=True)
+    ozinfo['status_nan'] = ozinfo['status_nan'].replace(0, np.nan)
     #make sure the end of the series is in the future
     ozinfo.loc[len(ozinfo.index)]=[date(2100,1,1), ozinfo.status.iat[-1], ozinfo.status_nan.iat[-1]]    
     ozinfo.datetime = pandas.to_datetime(ozinfo.datetime)


### PR DESCRIPTION
This PR is for address the insane amount of output from print statements that produces unusable amounts of data from each run. The goal is to remove most print statements that are not explicitly used for error handling and for those print statements that remain to be minimal useful information for addressing potential problems and tracking progress for runs. Examples are printing the filename as it progresses and configuration file names. It should continue to print all error messages as usual and adds a few useful messages such as if an empty DataFrame occurs in a get file data call. Finally, it also addresses any warnings from packages, especially pandas, which were also producing cluttered output.  