### PR TITLE
Minor fix - update build_gsinfo location to invdisk 

### DIFF
--- a/src/automation/run_16day_inventory.sh
+++ b/src/automation/run_16day_inventory.sh
@@ -3,8 +3,8 @@
 # the past 3 days to get updates for lagged data and plotting
 # the new data.
 
-SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
-OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
+SATINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/satinfo
+OZINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
 WORK_DIR=/invdisk/inventory-work
 

--- a/src/automation/run_32day_inventory.sh
+++ b/src/automation/run_32day_inventory.sh
@@ -3,8 +3,8 @@
 # the past 3 days to get updates for lagged data and plotting
 # the new data.
 
-SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
-OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
+SATINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/satinfo
+OZINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
 WORK_DIR=/invdisk/inventory-work
 

--- a/src/automation/run_3day_inventory.sh
+++ b/src/automation/run_3day_inventory.sh
@@ -3,8 +3,8 @@
 # the past 3 days to get updates for lagged data and plotting
 # the new data.
 
-SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
-OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
+SATINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/satinfo
+OZINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
 WORK_DIR=/invdisk/inventory-work
 

--- a/src/automation/run_full_inventory.sh
+++ b/src/automation/run_full_inventory.sh
@@ -2,8 +2,8 @@
 # This script is for running the automated inventory for 
 # the full period of each variable to get updates for added data
 
-SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
-OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
+SATINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/satinfo
+OZINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
 WORK_DIR=/invdisk/inventory-work
 

--- a/src/automation/run_plots_only.sh
+++ b/src/automation/run_plots_only.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -l
 # This script is for running an automation of the standard set of plots
 
-SATINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/satinfo
-OZINFO_DIR=/contrib/$USER/home/obs-inventory/build_gsinfo/ozinfo
+SATINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/satinfo
+OZINFO_DIR=/invdisk/obs-inventory-prod/build_gsinfo/ozinfo
 OUTPUT_LOC=/contrib/$USER/home/inventory-figures
 WORK_DIR=/invdisk/inventory-work
 


### PR DESCRIPTION
This is an update to address the location in the automation scripts to point to the build_gsinfo folder in obs-inventory-prod for consistency with using the new invdisk as the main location. 

To make the graphics accessible from other machines, the output directory remains on contrib per USER. 