### PR TITLE
Feature: plot observation counts on log axis 

### DIFF
--- a/src/plotting/plot_mysql_ioda.py
+++ b/src/plotting/plot_mysql_ioda.py
@@ -93,7 +93,7 @@ ax_dup.xaxis.set_minor_locator(mdates.YearLocator(1,month=1,day=1))
 ax_dup.set_xlim(daterange)
 
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = "ioda_line_observations_inventory_.png"
+file_name = "ioda_line_observations_inventory.png"
 if args.dev:
     file_name = "ioda_line_observations_inventory_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)

--- a/src/plotting/plot_mysql_ioda_version.py
+++ b/src/plotting/plot_mysql_ioda_version.py
@@ -93,7 +93,7 @@ ax_dup.xaxis.set_minor_locator(mdates.YearLocator(1,month=1,day=1))
 ax_dup.set_xlim(daterange)
 
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = "ioda_ver_line_observations_inventory_.png"
+file_name = "ioda_ver_line_observations_inventory.png"
 if args.dev:
     file_name = "ioda_ver_line_observations_inventory_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)

--- a/src/plotting/plot_mysql_multispectral_infrared_count.py
+++ b/src/plotting/plot_mysql_multispectral_infrared_count.py
@@ -34,7 +34,7 @@ def get_sensor(row):
 
 
 #read data from sql database of obs counts
-df = utils.get_distinct_bufr_by_sensors(['ssu', 'hirs'])
+df = utils.get_distinct_bufr_by_sensors(['observations/reanalysis/ssu', 'observations/reanalysis/hirs'])
 
 df['datetime'] = pd.to_datetime(df.obs_day)
 df['sensor'] = df.apply(get_sensor, axis=1)

--- a/src/plotting/plot_mysql_multispectral_infrared_count.py
+++ b/src/plotting/plot_mysql_multispectral_infrared_count.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+args = parser.parse_args()
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+
+def select_sensor(sensor, db_frame):
+    dftmp = db_frame.loc[db_frame['sensor']==sensor]
+    return dftmp
+
+def get_sensor(row):
+    directory = row['parent_dir']
+    sensor = directory.split("/")[2]
+    return sensor
+
+
+#read data from sql database of obs counts
+df = utils.get_distinct_bufr_by_sensors(['ssu', 'hirs'])
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+df['sensor'] = df.apply(get_sensor, axis=1)
+
+unique_sensor = df.sort_values('sensor', ascending=False).drop_duplicates('sensor')
+
+# Convert obs_day to datetime if it is not already in datetime format
+if not pd.api.types.is_datetime64_any_dtype(df['obs_day']):
+    df['obs_day'] = pd.to_datetime(df['obs_day'])
+
+# Sort the data by obs_day to ensure proper plotting
+df = df.sort_values(by='obs_day')
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+
+for index, row in unique_sensor.iterrows():
+    sensor = row['sensor']
+    single_sensor_df = df[(df['sensor'] == sensor)]
+
+    ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
+
+ax.set_title('Time Series for Multispectral Infrared')
+ax.set_xlabel('Observation Day')
+ax.set_ylabel('Observation Count')
+ax.set_yscale('log')  # log10 y-axis
+
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend()
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = "multispectral_infrared_count.png"
+if args.dev:
+    file_name = "multispectral_infrared_count_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -15,7 +15,7 @@ import obs_inv_utils.inventory_table_factory as itf
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
-parser.add_argument("-cat", dest='category', help="Category of sensors to plot", typ=str)
+parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
 args = parser.parse_args()
 
 category_dicts = {

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -73,21 +73,34 @@ df = utils.get_distinct_bufr_by_sensors(sensor_list)
 df['datetime'] = pd.to_datetime(df.obs_day)
 df['sensor'] = df.apply(get_sensor, axis=1)
 
-unique_sensor = df.sort_values('sensor', ascending=False).drop_duplicates('sensor')
+# Group by sensor and obs_day, summing obs_count
+grouped_df = df.groupby(['sensor', 'obs_day'], as_index=False)['obs_count'].sum()
+
+# Convert obs_day to datetime if needed
+if not pd.api.types.is_datetime64_any_dtype(grouped_df['obs_day']):
+    grouped_df['obs_day'] = pd.to_datetime(grouped_df['obs_day'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by='obs_day')
+
+# Get unique sensors
+unique_sensors = grouped_df['sensor'].unique()
+
+#unique_sensors = df.sort_values('sensor', ascending=False).drop_duplicates('sensor')
 
 # Convert obs_day to datetime if it is not already in datetime format
-if not pd.api.types.is_datetime64_any_dtype(df['obs_day']):
-    df['obs_day'] = pd.to_datetime(df['obs_day'])
+# if not pd.api.types.is_datetime64_any_dtype(df['obs_day']):
+#     df['obs_day'] = pd.to_datetime(df['obs_day'])
 
-# Sort the data by obs_day to ensure proper plotting
-df = df.sort_values(by='obs_day')
+# # Sort the data by obs_day to ensure proper plotting
+# df = df.sort_values(by='obs_day')
 
 # Create the plot
 fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 
-for index, row in unique_sensor.iterrows():
+for index, row in unique_sensors.iterrows():
     sensor = row['sensor']
-    single_sensor_df = df[(df['sensor'] == sensor)]
+    single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
     ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
 

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -60,7 +60,7 @@ def make_sensor_list_by_category(category):
     sensor_list = []
     if category in category_dicts:
         for cat in category_dicts[category]:
-            sensor_list.append("observations/reanalysis/" + {cat})
+            sensor_list.append("observations/reanalysis/" + cat)
     else: 
         print(f"No category found with name {category}")
     return sensor_list

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -15,7 +15,31 @@ import obs_inv_utils.inventory_table_factory as itf
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-cat", dest='category', help="Category of sensors to plot", typ=str)
 args = parser.parse_args()
+
+category_dicts = {
+    'AMV': {'amv'},
+    'GPS': {'gps'},
+    'geo_rad' : {'geo'},
+    'hyper_infrared': {'cris', 'iasi', 'airs'}, 
+    'multi_infrared': {'ssu', 'hirs'}, 
+    'micro_imagers': {'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis'},
+    'micro_sounders': {'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}, 
+    'ozone': {'ozone'},
+}
+
+category_titles = {
+    'AMV': 'AMV',
+    'GPS': 'GPS',
+    'geo_rad': 'Geostationary Radiances',
+    'hyper_infrared': 'Hyperspectral Infrared',
+    'multi_infrared': 'Multispectral Infrared',
+    'micro_imagers': 'Microwave Imagers', 
+    'micro_sounders': 'Microwave Sounders', 
+    'ozone': 'Ozone',
+}
+
 
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
@@ -32,9 +56,19 @@ def get_sensor(row):
     sensor = directory.split("/")[2]
     return sensor
 
+def make_sensor_list_by_category(category):
+    sensor_list = []
+    if category in category_dicts:
+        for cat in category_dicts[category]:
+            sensor_list.append("observations/reanalysis/" + {cat})
+    else: 
+        print(f"No category found with name {category}")
+    return sensor_list
 
+
+sensor_list = make_sensor_list_by_category(args.category)
 #read data from sql database of obs counts
-df = utils.get_distinct_bufr_by_sensors(['observations/reanalysis/ssu', 'observations/reanalysis/hirs'])
+df = utils.get_distinct_bufr_by_sensors(sensor_list)
 
 df['datetime'] = pd.to_datetime(df.obs_day)
 df['sensor'] = df.apply(get_sensor, axis=1)
@@ -57,11 +91,10 @@ for index, row in unique_sensor.iterrows():
 
     ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
 
-ax.set_title('Time Series for Multispectral Infrared')
+ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
-
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
@@ -74,9 +107,9 @@ ax.legend()
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = "multispectral_infrared_count.png"
+file_name = f"{args.category}_count.png"
 if args.dev:
-    file_name = "multispectral_infrared_count_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"{args.category}_count_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -42,7 +42,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def plot_one_line(dftmp, yloc):
     plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
@@ -98,6 +98,7 @@ ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -86,20 +86,9 @@ grouped_df = grouped_df.sort_values(by='obs_day')
 # Get unique sensors
 unique_sensors = grouped_df['sensor'].unique()
 
-#unique_sensors = df.sort_values('sensor', ascending=False).drop_duplicates('sensor')
-
-# Convert obs_day to datetime if it is not already in datetime format
-# if not pd.api.types.is_datetime64_any_dtype(df['obs_day']):
-#     df['obs_day'] = pd.to_datetime(df['obs_day'])
-
-# # Sort the data by obs_day to ensure proper plotting
-# df = df.sort_values(by='obs_day')
-
 # Create the plot
 fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 
-# for index, row in unique_sensors.iterrows():
-#     sensor = row['sensor']
 for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 

--- a/src/plotting/plot_mysql_obs_count_cat.py
+++ b/src/plotting/plot_mysql_obs_count_cat.py
@@ -98,8 +98,9 @@ unique_sensors = grouped_df['sensor'].unique()
 # Create the plot
 fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 
-for index, row in unique_sensors.iterrows():
-    sensor = row['sensor']
+# for index, row in unique_sensors.iterrows():
+#     sensor = row['sensor']
+for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
     ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -82,7 +82,7 @@ grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['obs_count'].su
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 
 # Sort the grouped data
-grouped_df = grouped_df.sort_values(by='obs_day')
+grouped_df = grouped_df.sort_values(by='date_only')
 
 # Get unique sensors
 unique_sensors = grouped_df['sensor'].unique()

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -93,7 +93,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
-    ax.scatter(single_sensor_df['date_only'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
+    ax.plot(single_sensor_df['date_only'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
 
 ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -113,7 +113,7 @@ plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"{args.category}_count_daily.png"
 if args.dev:
-    file_name = f"{args.category}_count_dailyl_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"{args.category}_count_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
 parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
+parser.add_argument("-window", dest='window', help="Category of sensors to plot", type=int, default=1)
 args = parser.parse_args()
 
 category_dicts = {
@@ -84,6 +85,8 @@ grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 # Sort the grouped data
 grouped_df = grouped_df.sort_values(by='date_only')
 
+grouped_df['rolling_avg'] = grouped_df['obs_count'].rolling(window=args.window, min_periods=1).mean()
+
 # Get unique sensors
 unique_sensors = grouped_df['sensor'].unique()
 
@@ -93,7 +96,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
-    ax.plot(single_sensor_df['date_only'], single_sensor_df['obs_count'], label=f'Sensor {sensor}')
+    ax.plot(single_sensor_df['date_only'], single_sensor_df['rolling_avg'], label=f'Sensor {sensor}')
 
 ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -93,7 +93,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
-    ax.plot(single_sensor_df['date_only'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
+    ax.plot(single_sensor_df['date_only'], single_sensor_df['obs_count'], label=f'Sensor {sensor}')
 
 ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
+args = parser.parse_args()
+
+category_dicts = {
+    'AMV': {'amv'},
+    'GPS': {'gps'},
+    'geo_rad' : {'geo'},
+    'hyper_infrared': {'cris', 'iasi', 'airs'}, 
+    'multi_infrared': {'ssu', 'hirs'}, 
+    'micro_imagers': {'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis'},
+    'micro_sounders': {'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}, 
+    'ozone': {'ozone'},
+}
+
+category_titles = {
+    'AMV': 'AMV',
+    'GPS': 'GPS',
+    'geo_rad': 'Geostationary Radiances',
+    'hyper_infrared': 'Hyperspectral Infrared',
+    'multi_infrared': 'Multispectral Infrared',
+    'micro_imagers': 'Microwave Imagers', 
+    'micro_sounders': 'Microwave Sounders', 
+    'ozone': 'Ozone',
+}
+
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+
+def select_sensor(sensor, db_frame):
+    dftmp = db_frame.loc[db_frame['sensor']==sensor]
+    return dftmp
+
+def get_sensor(row):
+    directory = row['parent_dir']
+    sensor = directory.split("/")[2]
+    return sensor
+
+def make_sensor_list_by_category(category):
+    sensor_list = []
+    if category in category_dicts:
+        for cat in category_dicts[category]:
+            sensor_list.append("observations/reanalysis/" + cat)
+    else: 
+        print(f"No category found with name {category}")
+    return sensor_list
+
+
+sensor_list = make_sensor_list_by_category(args.category)
+#read data from sql database of obs counts
+df = utils.get_distinct_bufr_by_sensors(sensor_list)
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+df['sensor'] = df.apply(get_sensor, axis=1)
+
+df['date_only'] = df['datetime'].dt.date
+
+# Group by sensor and obs_day-- date only, summing obs_count
+grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['obs_count'].sum()
+
+# Convert obs_day to datetime if needed
+if not pd.api.types.is_datetime64_any_dtype(grouped_df['obs_day']):
+    grouped_df['obs_day'] = pd.to_datetime(grouped_df['obs_day'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by='obs_day')
+
+# Get unique sensors
+unique_sensors = grouped_df['sensor'].unique()
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+
+for sensor in unique_sensors:
+    single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
+
+    ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
+
+ax.set_title(f'Time Series for {category_titles[args.category]}')
+ax.set_xlabel('Observation Day')
+ax.set_ylabel('Observation Count')
+ax.set_yscale('log')  # log10 y-axis
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend()
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = f"{args.category}_count_daily.png"
+if args.dev:
+    file_name = f"{args.category}_count_dailyl_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -43,7 +43,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def plot_one_line(dftmp, yloc):
     plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
@@ -102,6 +102,7 @@ ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -79,8 +79,7 @@ df['date_only'] = df['datetime'].dt.date
 grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['obs_count'].sum()
 
 # Convert obs_day to datetime if needed
-if not pd.api.types.is_datetime64_any_dtype(grouped_df['obs_day']):
-    grouped_df['obs_day'] = pd.to_datetime(grouped_df['obs_day'])
+grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 
 # Sort the grouped data
 grouped_df = grouped_df.sort_values(by='obs_day')
@@ -94,7 +93,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for sensor in unique_sensors:
     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
-    ax.scatter(single_sensor_df['obs_day'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
+    ax.scatter(single_sensor_df['date_only'], single_sensor_df['obs_count'], marker='o', label=f'Sensor {sensor}')
 
 ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_cat_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_daily.py
@@ -114,9 +114,9 @@ ax.legend()
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = f"{args.category}_count_daily.png"
+file_name = f"{args.category}_count_avg_{args.window}_days.png"
 if args.dev:
-    file_name = f"{args.category}_count_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"{args.category}_count_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat_ice.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ice.py
@@ -21,54 +21,54 @@ parser.add_argument("-cats", dest='cat_list', help="Categories of sensors to plo
 args = parser.parse_args()
 
 category_dicts = {
-    'temperature': {'TEMPERATURE'},
-    'spec humid': {'SPECIFIC HUMIDITY'},
-    'precip' : {'PRECIPITABLE H20'},
-    'pressure': {'PRESSURE'}, 
-    'wind comp': {'WIND COMPONENTS'}, 
-    'height': {'HEIGHT'},
-    'conv': {'TEMPERATURE', 'SPECIFIC HUMIDITY', 'PRESSURE', 'WIND COMPONENTS', 'HEIGHT'}
+    'icec_nh' : {'observations/reanalysis/icec/nsidc/nh'},
+    'icec_sh' : {'observations/reanalysis/icec/nsidc/sh'},
+    'icec_emc' : {'observations/reanalysis/icec/emc'},
+    'icefb': {'observations/reanalysis/icefb'}, 
 }
 
 category_titles = {
-    'temperature': 'Temperature',
-    'spec humid': 'Specific Humidity',
-    'precip': 'Precipitable H20',
-    'pressure': 'Pressure',
-    'wind comp': 'Wind Components',
-    'height': 'Height', 
-    'conv': 'Conventional Data',
+    'icec_nh': 'Ice Concentration NSIDC NH',
+    'icec_sh': 'Ice Concentration NSIDC SH',
+    'icec_emc': 'Ice Concentration EMC Combined',
+    'icefb': 'Ice Free Board',
 }
 
 
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
 
-def select_variable(variable, db_frame):
-    dftmp = db_frame.loc[db_frame['variable']==variable]
+def select_sensor(sensor, db_frame):
+    dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp
 
+def get_sensor(row):
+    directory = row['parent_dir']
+    sensor = directory.split("/")[2]
+    return sensor
+
 def get_category(row):
-    variable = row['variable']
-    for cat in args.cat_list:
-        if variable in category_dicts.get(cat, set()):
-            return cat
+    parent_dir = row['parent_dir']        
+    for category, prefixes in category_dicts.items():
+        if category in args.cat_list:
+            for prefix in prefixes:
+                if parent_dir.startswith(prefix):
+                    return category
     return None
 
-def make_variable_list_by_categories(cat_list):
-    variable_list = []
+def make_sensor_list_by_category(cat_list):
+    sensor_list = []
     for category in cat_list:
         if category in category_dicts:
             for cat in category_dicts[category]:
-                variable_list.append(cat)
+                sensor_list.append(cat)
         else: 
             print(f"No category found with name {category}")
-    return variable_list
+    return sensor_list
 
-
-variable_list = make_variable_list_by_categories(args.cat_list)
+sensor_list = make_sensor_list_by_category(args.cat_list)
 #read data from sql database of obs counts
-df = utils.get_distinct_prepbufr_by_variable(variable_list)
+df = utils.get_ioda_nc_by_sensor(sensor_list)
 
 df['datetime'] = pd.to_datetime(df.obs_day)
 df['category'] = df.apply(get_category, axis=1)
@@ -76,21 +76,21 @@ df['category'] = df.apply(get_category, axis=1)
 df['date_only'] = df['datetime'].dt.date
 
 # Group by sensor and obs_day-- date only, summing obs_count
-grouped_df = df.groupby(['category', 'date_only'], as_index=False)['tot'].sum()
+grouped_df = df.groupby(['category', 'date_only'], as_index=False)['var_count'].sum()
 
 # Convert obs_day to datetime if needed
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 
 # Sort the grouped data
-grouped_df = grouped_df.sort_values(by=['category','date_only'])
+grouped_df = grouped_df.sort_values(by='date_only')
 
-grouped_df['rolling_avg'] = grouped_df.groupby('category')['tot'].transform(lambda x: x.rolling(window=args.window, min_periods=1).mean())
+grouped_df['rolling_avg'] = grouped_df.groupby('category')['var_count'].transform(lambda x: x.rolling(window=args.window, min_periods=1).mean())
 
 # Get unique sensors
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]
@@ -113,9 +113,9 @@ ax.legend(fontsize = 12)
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = f"conv_time_series_combo_avg_{args.window}_days.png"
+file_name = f"ice_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
-    file_name = f"conv_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"ice_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_cat_ice.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ice.py
@@ -90,7 +90,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['var_count'].transfor
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 8))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_cat_ice.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ice.py
@@ -97,9 +97,9 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 20) #16
-ax.set_xlabel('Observation Day', fontsize = 18) #14
-ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
+ax.set_title(f'{args.title}', fontsize = 18) #16
+ax.set_xlabel('Observation Day', fontsize = 17) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 17) #14
 ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
@@ -107,10 +107,11 @@ ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
+ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 15) #11
+ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_cat_ice.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ice.py
@@ -102,17 +102,17 @@ ax.set_xlabel('Observation Day', fontsize = 14)
 ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
-ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
+ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 12)
+ax.legend(fontsize = 11)
 
 plt.tight_layout()
-plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+# plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"ice_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
     file_name = f"ice_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"

--- a/src/plotting/plot_mysql_obs_count_cat_ice.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ice.py
@@ -36,7 +36,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
@@ -97,10 +97,11 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 16)
-ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
+ax.set_title(f'{args.title}', fontsize = 20) #16
+ax.set_xlabel('Observation Day', fontsize = 18) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
@@ -109,7 +110,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 11)
+ax.legend(fontsize = 15) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
@@ -38,7 +38,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
@@ -92,6 +92,7 @@ ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
@@ -40,9 +40,6 @@ category_titles = {
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
 
-def plot_one_line(dftmp, yloc):
-    plt.plot(dftmp.datetime, yloc*dftmp.var_count.astype('bool'),'|',color='black',markersize=5)
-
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp

--- a/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
+++ b/src/plotting/plot_mysql_obs_count_cat_ocn_daily.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
+args = parser.parse_args()
+
+category_dicts = {
+    'sst': {'sst'},
+    'sss': {'sss'},
+    'icec' : {'icec'},
+    'icefb': {'icefb'}, 
+    'adt': {'adt'}, 
+    'insitu': {'insitu'},
+}
+
+category_titles = {
+    'sst': 'SST',
+    'sss': 'SSS',
+    'icec': 'Ice Concentration',
+    'icefb': 'Ice Free Board',
+    'adt': 'ADT',
+    'insitu': 'Ocean Insitu', 
+}
+
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.var_count.astype('bool'),'|',color='black',markersize=5)
+
+def select_sensor(sensor, db_frame):
+    dftmp = db_frame.loc[db_frame['sensor']==sensor]
+    return dftmp
+
+def get_sensor(row):
+    directory = row['parent_dir']
+    sensor = directory.split("/")[2]
+    return sensor
+
+def make_sensor_list_by_category(category):
+    sensor_list = []
+    if category in category_dicts:
+        for cat in category_dicts[category]:
+            sensor_list.append("observations/reanalysis/" + cat)
+    else: 
+        print(f"No category found with name {category}")
+    return sensor_list
+
+
+sensor_list = make_sensor_list_by_category(args.category)
+#read data from sql database of obs counts
+df = utils.get_ioda_nc_by_sensor(sensor_list)
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+df['sensor'] = df.apply(get_sensor, axis=1)
+
+df['date_only'] = df['datetime'].dt.date
+
+# Group by sensor and obs_day-- date only, summing obs_count
+grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['var_count'].sum()
+
+# Convert obs_day to datetime if needed
+grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by='date_only')
+
+# Get unique sensors
+unique_sensors = grouped_df['sensor'].unique()
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+
+for sensor in unique_sensors:
+    single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
+
+    ax.plot(single_sensor_df['date_only'], single_sensor_df['var_count'], label=f'Sensor {sensor}')
+
+ax.set_title(f'Time Series for {category_titles[args.category]}')
+ax.set_xlabel('Observation Day')
+ax.set_ylabel('Observation Count')
+ax.set_yscale('log')  # log10 y-axis
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend()
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = f"{args.category}_count_daily.png"
+if args.dev:
+    file_name = f"{args.category}_count_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
+args = parser.parse_args()
+
+category_dicts = {
+    'AMV': {'amv'},
+    'GPS': {'gps'},
+    'geo_rad' : {'geo'},
+    'hyper_infrared': {'cris', 'iasi', 'airs'}, 
+    'multi_infrared': {'ssu', 'hirs'}, 
+    'micro_imagers': {'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis'},
+    'micro_sounders': {'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}, 
+    'ozone': {'ozone'},
+    'polar_orbit_BT': {'cris', 'iasi', 'airs', 'ssu', 'hirs', 'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis', 'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}
+}
+
+category_titles = {
+    'AMV': 'AMV',
+    'GPS': 'GPS',
+    'geo_rad': 'Geostationary Radiances',
+    'hyper_infrared': 'Hyperspectral Infrared',
+    'multi_infrared': 'Multispectral Infrared',
+    'micro_imagers': 'Microwave Imagers', 
+    'micro_sounders': 'Microwave Sounders', 
+    'ozone': 'Ozone',
+    'polar_orbit_BT': 'Polar Orbiting Brightness Temperature'
+}
+
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+
+def select_sensor(sensor, db_frame):
+    dftmp = db_frame.loc[db_frame['sensor']==sensor]
+    return dftmp
+
+def get_sensor(row):
+    directory = row['parent_dir']
+    sensor = directory.split("/")[2]
+    return sensor
+
+def make_sensor_list_by_category(category):
+    sensor_list = []
+    if category in category_dicts:
+        for cat in category_dicts[category]:
+            sensor_list.append("observations/reanalysis/" + cat)
+    else: 
+        print(f"No category found with name {category}")
+    return sensor_list
+
+
+sensor_list = make_sensor_list_by_category(args.category)
+#read data from sql database of obs counts
+df = utils.get_distinct_bufr_by_sensors(sensor_list)
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+# df['sensor'] = df.apply(get_sensor, axis=1)
+
+df['date_only'] = df['datetime'].dt.date
+
+# Group by sensor and obs_day-- date only, summing obs_count
+grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['obs_count'].sum()
+
+# Convert obs_day to datetime if needed
+grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by='date_only')
+
+# Get unique sensors
+#unique_sensors = grouped_df['sensor'].unique()
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+
+# for sensor in unique_sensors:
+#     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
+
+ax.plot(grouped_df['date_only'], grouped_df['obs_count'])
+
+ax.set_title(f'Total Daily Observations for {category_titles[args.category]}')
+ax.set_xlabel('Observation Day')
+ax.set_ylabel('Observation Count')
+ax.set_yscale('log')  # log10 y-axis
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend()
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = f"{args.category}_combo_daily.png"
+if args.dev:
+    file_name = f"{args.category}_combo_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -116,9 +116,9 @@ ax.legend()
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = f"{args.category}_combo_daily.png"
+file_name = f"{args.category}_combo_avg_{args.window}_days.png"
 if args.dev:
-    file_name = f"{args.category}_combo_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"{args.category}_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
 parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
+parser.add_argument("-window", dest='window', help="Category of sensors to plot", type=int, default=1)
 args = parser.parse_args()
 
 category_dicts = {
@@ -86,6 +87,8 @@ grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 # Sort the grouped data
 grouped_df = grouped_df.sort_values(by='date_only')
 
+grouped_df['rolling_avg'] = grouped_df['obs_count'].rolling(window=args.window, min_periods=1).mean()
+
 # Get unique sensors
 #unique_sensors = grouped_df['sensor'].unique()
 
@@ -95,7 +98,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 # for sensor in unique_sensors:
 #     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
-ax.plot(grouped_df['date_only'], grouped_df['obs_count'])
+ax.plot(grouped_df['date_only'], grouped_df['rolling_avg'])
 
 ax.set_title(f'Total Daily Observations for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -62,7 +62,7 @@ def make_sensor_list_by_category(category):
         for cat in category_dicts[category]:
             sensor_list.append("observations/reanalysis/" + cat)
     else: 
-        print(f"No category found with name {category}")
+        raise ValueError(f"No category found with name {category}. Must provide a valid category from {list(category_dicts.keys())}.")
     return sensor_list
 
 
@@ -71,7 +71,6 @@ sensor_list = make_sensor_list_by_category(args.category)
 df = utils.get_distinct_bufr_by_sensors(sensor_list)
 
 df['datetime'] = pd.to_datetime(df.obs_day)
-# df['sensor'] = df.apply(get_sensor, axis=1)
 
 df['date_only'] = df['datetime'].dt.date
 
@@ -86,14 +85,8 @@ grouped_df = grouped_df.sort_values(by='date_only')
 
 grouped_df['rolling_avg'] = grouped_df['obs_count'].rolling(window=args.window, min_periods=1).mean()
 
-# Get unique sensors
-#unique_sensors = grouped_df['sensor'].unique()
-
 # Create the plot
 fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
-
-# for sensor in unique_sensors:
-#     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
 
 ax.plot(grouped_df['date_only'], grouped_df['rolling_avg'])
 

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -112,7 +112,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend()
+#ax.legend()
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -45,7 +45,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
@@ -101,6 +101,7 @@ ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -78,7 +78,7 @@ df['datetime'] = pd.to_datetime(df.obs_day)
 df['date_only'] = df['datetime'].dt.date
 
 # Group by sensor and obs_day-- date only, summing obs_count
-grouped_df = df.groupby(['sensor', 'date_only'], as_index=False)['obs_count'].sum()
+grouped_df = df.groupby(['date_only'], as_index=False)['obs_count'].sum()
 
 # Convert obs_day to datetime if needed
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -47,9 +47,6 @@ category_titles = {
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
 
-def plot_one_line(dftmp, yloc):
-    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
-
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp

--- a/src/plotting/plot_mysql_obs_count_combo_daily.py
+++ b/src/plotting/plot_mysql_obs_count_combo_daily.py
@@ -100,7 +100,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 
 ax.plot(grouped_df['date_only'], grouped_df['rolling_avg'])
 
-ax.set_title(f'Total Daily Observations for {category_titles[args.category]}')
+ax.set_title(f'Time Series for {category_titles[args.category]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -115,9 +115,9 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 20) #16
-ax.set_xlabel('Observation Day', fontsize = 18) #14
-ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
+ax.set_title(f'{args.title}', fontsize = 18) #16
+ax.set_xlabel('Observation Day', fontsize = 16) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 16) #14
 ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
@@ -125,10 +125,11 @@ ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
+ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 15) #11
+ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -15,8 +15,9 @@ import obs_inv_utils.inventory_table_factory as itf
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
-parser.add_argument("-cat", dest='category', help="Category of sensors to plot", type=str)
-parser.add_argument("-window", dest='window', help="Rolling average of window size", type=int, default=1)
+parser.add_argument("-window", dest='window', help=" Rolling average of window size", type=int, default=1)
+parser.add_argument("-title", dest='title', help='Title for the plot', type=str, default="Time Series of Observation Count")
+parser.add_argument("-cats", dest='cat_list', help="Categories of sensors to plot", type=str, nargs='+')
 args = parser.parse_args()
 
 category_dicts = {
@@ -54,32 +55,40 @@ def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp
 
+def get_category(sensor, cat_list):
+    for cat in cat_list:
+        if sensor in category_dicts.get(cat, set()):
+            return cat
+    return None
+
 def get_sensor(row):
     directory = row['parent_dir']
     sensor = directory.split("/")[2]
     return sensor
 
-def make_sensor_list_by_category(category):
+def make_sensor_list_by_categories(cat_list):
     sensor_list = []
-    if category in category_dicts:
-        for cat in category_dicts[category]:
-            sensor_list.append("observations/reanalysis/" + cat)
-    else: 
-        print(f"No category found with name {category}")
+    for category in cat_list:
+        if category in category_dicts:
+            for cat in category_dicts[category]:
+                sensor_list.append("observations/reanalysis/" + cat)
+        else: 
+            print(f"No category found with name {category}")
     return sensor_list
 
 
-sensor_list = make_sensor_list_by_category(args.category)
+sensor_list = make_sensor_list_by_categories(args.cats)
 #read data from sql database of obs counts
 df = utils.get_distinct_bufr_by_sensors(sensor_list)
 
 df['datetime'] = pd.to_datetime(df.obs_day)
-# df['sensor'] = df.apply(get_sensor, axis=1)
+df['sensor'] = df.apply(get_sensor, axis=1)
+df['category'] = df.apply(get_category, axis=1)
 
 df['date_only'] = df['datetime'].dt.date
 
 # Group by sensor and obs_day-- date only, summing obs_count
-grouped_df = df.groupby(['date_only'], as_index=False)['obs_count'].sum()
+grouped_df = df.groupby(['category', 'date_only'], as_index=False)['obs_count'].sum()
 
 # Convert obs_day to datetime if needed
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
@@ -90,17 +99,17 @@ grouped_df = grouped_df.sort_values(by='date_only')
 grouped_df['rolling_avg'] = grouped_df['obs_count'].rolling(window=args.window, min_periods=1).mean()
 
 # Get unique sensors
-#unique_sensors = grouped_df['sensor'].unique()
+unique_categories = grouped_df['category'].unique()
 
 # Create the plot
 fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 
-# for sensor in unique_sensors:
-#     single_sensor_df = grouped_df[(grouped_df['sensor'] == sensor)]
+for category in unique_categories:
+    single_category_df = grouped_df[(grouped_df['category'] == category)]
 
-ax.plot(grouped_df['date_only'], grouped_df['rolling_avg'])
+    ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[args.category]}')
 
-ax.set_title(f'Time Series for {category_titles[args.category]}')
+ax.set_title(f'{args.title}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
@@ -112,13 +121,13 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-#ax.legend()
+ax.legend()
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = f"{args.category}_combo_avg_{args.window}_days.png"
+file_name = f"atm_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
-    file_name = f"{args.category}_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"atm_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -103,26 +103,26 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['obs_count'].transfor
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}')
-ax.set_xlabel('Observation Day')
-ax.set_ylabel('Observation Count')
+ax.set_title(f'{args.title}', fontsize = 16)
+ax.set_xlabel('Observation Day', fontsize = 14)
+ax.set_ylabel('Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend()
+ax.legend(fontsize = 12)
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -108,7 +108,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]
 
-    ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[args.category]}')
+    ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
 ax.set_title(f'{args.title}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -48,9 +48,6 @@ category_titles = {
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
 
-def plot_one_line(dftmp, yloc):
-    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
-
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp
@@ -112,7 +109,7 @@ for category in unique_categories:
 
 ax.set_title(f'{args.title}', fontsize = 16)
 ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Daily Observation Count', fontsize = 14)
+ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -25,11 +25,14 @@ category_dicts = {
     'GPS': {'gps'},
     'geo_rad' : {'geo'},
     'hyper_infrared': {'cris', 'iasi', 'airs'}, 
-    'multi_infrared': {'ssu', 'hirs'}, 
+    'multi_infrared': {'ssu', 'hirs/1bhrs2', 'hirs/1bhrs3', 'hirs/1bhrs4'}, 
     'micro_imagers': {'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis'},
     'micro_sounders': {'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}, 
     'ozone': {'ozone'},
-    'polar_orbit_BT': {'cris', 'iasi', 'airs', 'ssu', 'hirs', 'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis', 'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'}
+    'polar_orbit_BT': {'cris', 'iasi', 'airs', 'ssu', 'hirs/1bhrs2', 'hirs/1bhrs3', 'hirs/1bhrs4' , 'gmi', 'amsr2', 'tmi', 'amsre', 'ssmi', 'ssmis', 'saphir', 'mhs', 'atms', 'msu', 'amsub', 'amsua'},
+    'tovs': {'hirs/1bhrs2', 'ssu', 'msu'},
+    'atovs': {'hirs/1bhrs3', 'hirs/1bhrs4', 'amsua', 'amsub', 'mhs'},
+    'post-atovs': {'cris', 'atms'}
 }
 
 category_titles = {
@@ -41,7 +44,10 @@ category_titles = {
     'micro_imagers': 'Microwave Imagers', 
     'micro_sounders': 'Microwave Sounders', 
     'ozone': 'Ozone',
-    'polar_orbit_BT': 'Polar Orbiting Brightness Temperature'
+    'polar_orbit_BT': 'Polar Orbiting Brightness Temperature',
+    'tovs': 'TOVS',
+    'atovs': 'ATOVS',
+    'post-atovs': 'Post-ATOVS',
 }
 
 
@@ -62,6 +68,8 @@ def get_category(row):
 def get_sensor(row):
     directory = row['parent_dir']
     sensor = directory.split("/")[2]
+    if sensor == 'hirs':
+        sensor = 'hirs/' + directory.split("/")[3]
     return sensor
 
 def make_sensor_list_by_categories(cat_list):

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -95,9 +95,9 @@ grouped_df = df.groupby(['category', 'date_only'], as_index=False)['obs_count'].
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 
 # Sort the grouped data
-grouped_df = grouped_df.sort_values(by='date_only')
+grouped_df = grouped_df.sort_values(by=['category','date_only'])
 
-grouped_df['rolling_avg'] = grouped_df['obs_count'].rolling(window=args.window, min_periods=1).mean()
+grouped_df['rolling_avg'] = grouped_df.groupby('category')['obs_count'].transform(lambda x: x.rolling(window=args.window, min_periods=1).mean())
 
 # Get unique sensors
 unique_categories = grouped_df['category'].unique()

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -100,7 +100,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['obs_count'].transfor
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 4))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -52,7 +52,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
@@ -115,10 +115,11 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 16)
-ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
+ax.set_title(f'{args.title}', fontsize = 20) #16
+ax.set_xlabel('Observation Day', fontsize = 18) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
@@ -127,7 +128,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 11)
+ax.legend(fontsize = 15) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -100,7 +100,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['obs_count'].transfor
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -100,7 +100,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['obs_count'].transfor
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(10, 4))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 8))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -132,7 +132,6 @@ ax.grid(True)
 ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
-# plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"atm_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
     file_name = f"atm_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -112,7 +112,7 @@ for category in unique_categories:
 
 ax.set_title(f'{args.title}', fontsize = 16)
 ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Observation Count', fontsize = 14)
+ax.set_ylabel('Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -55,8 +55,9 @@ def select_sensor(sensor, db_frame):
     dftmp = db_frame.loc[db_frame['sensor']==sensor]
     return dftmp
 
-def get_category(sensor, cat_list):
-    for cat in cat_list:
+def get_category(row):
+    sensor = row['sensor']
+    for cat in args.cat_list:
         if sensor in category_dicts.get(cat, set()):
             return cat
     return None
@@ -77,7 +78,7 @@ def make_sensor_list_by_categories(cat_list):
     return sensor_list
 
 
-sensor_list = make_sensor_list_by_categories(args.cats)
+sensor_list = make_sensor_list_by_categories(args.cat_list)
 #read data from sql database of obs counts
 df = utils.get_distinct_bufr_by_sensors(sensor_list)
 

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -115,9 +115,9 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 18) #16
-ax.set_xlabel('Observation Day', fontsize = 16) #14
-ax.set_ylabel('Average Daily Observation Count', fontsize = 16) #14
+ax.set_title(f'{args.title}', fontsize = 19) #16
+ax.set_xlabel('Observation Day', fontsize = 17) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 17) #14
 ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
@@ -129,7 +129,7 @@ ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 12) #11
+ax.legend(fontsize = 13) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -112,17 +112,17 @@ ax.set_xlabel('Observation Day', fontsize = 14)
 ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
-ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
+ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 12)
+ax.legend(fontsize = 11)
 
 plt.tight_layout()
-plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+# plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"atm_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
     file_name = f"atm_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"

--- a/src/plotting/plot_mysql_obs_count_combo_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_combo_multiline.py
@@ -115,7 +115,7 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 19) #16
+ax.set_title(f'{args.title}', fontsize = 18) #16
 ax.set_xlabel('Observation Day', fontsize = 17) #14
 ax.set_ylabel('Average Daily Observation Count', fontsize = 17) #14
 ax.set_yscale('log')  # log10 y-axis
@@ -129,7 +129,7 @@ ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 13) #11
+ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -102,17 +102,17 @@ ax.set_xlabel('Observation Day', fontsize = 14)
 ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
-ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
+ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 12)
+ax.legend(fontsize = 11)
 
 plt.tight_layout()
-plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+# plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"conv_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
     file_name = f"conv_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -90,7 +90,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['tot'].transform(lamb
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -90,7 +90,7 @@ grouped_df['rolling_avg'] = grouped_df.groupby('category')['tot'].transform(lamb
 unique_categories = grouped_df['category'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(10, 6))  # Increase figure width
+fig, ax = plt.subplots(figsize=(10, 8))  # Increase figure width
 
 for category in unique_categories:
     single_category_df = grouped_df[(grouped_df['category'] == category)]

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -42,7 +42,7 @@ category_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_variable(variable, db_frame):
     dftmp = db_frame.loc[db_frame['variable']==variable]
@@ -97,10 +97,11 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 16)
-ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
+ax.set_title(f'{args.title}', fontsize = 20) #16
+ax.set_xlabel('Observation Day', fontsize = 18) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
@@ -109,7 +110,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 11)
+ax.legend(fontsize = 15) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -114,7 +114,6 @@ ax.grid(True)
 ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
-# plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
 file_name = f"conv_time_series_combo_avg_{args.window}_days.png"
 if args.dev:
     file_name = f"conv_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -97,9 +97,9 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 20) #16
-ax.set_xlabel('Observation Day', fontsize = 18) #14
-ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
+ax.set_title(f'{args.title}', fontsize = 18) #16
+ax.set_xlabel('Observation Day', fontsize = 17) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 17) #14
 ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
@@ -111,7 +111,7 @@ ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 15) #11
+ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-window", dest='window', help=" Rolling average of window size", type=int, default=1)
+parser.add_argument("-title", dest='title', help='Title for the plot', type=str, default="Time Series of Observation Count")
+parser.add_argument("-cats", dest='cat_list', help="Categories of sensors to plot", type=str, nargs='+')
+args = parser.parse_args()
+
+category_dicts = {
+    'temperature': {'TEMPERATURE'},
+    'spec humid': {'SPECIFIC HUMIDITY'},
+    'precip' : {'PRECIPITABLE H20'},
+    'pressure': {'PRESSURE'}, 
+    'wind comp': {'WIND COMPONENTS'}, 
+    'height': {'HEIGHT'},
+    'conv': {'TEMPERATURE', 'SPECIFIC HUMIDITY', 'PRESSURE', 'WIND COMPONENTS', 'HEIGHT'}
+}
+
+category_titles = {
+    'temperature': 'Temperature',
+    'spec humid': 'Specific Humidity',
+    'precip': 'Precipitable H20',
+    'pressure': 'Pressure',
+    'wind comp': 'Wind Components',
+    'height': 'Height', 
+    'conv': 'Conventional Data',
+}
+
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+
+def select_variable(variable, db_frame):
+    dftmp = db_frame.loc[db_frame['variable']==variable]
+    return dftmp
+
+def get_category(row):
+    variable = row['variable']
+    for cat in args.cat_list:
+        if variable in category_dicts.get(cat, set()):
+            return cat
+    return None
+
+def make_variable_list_by_categories(cat_list):
+    variable_list = []
+    for category in cat_list:
+        if category in category_dicts:
+            for cat in category_dicts[category]:
+                variable_list.append(cat)
+        else: 
+            print(f"No category found with name {category}")
+    return variable_list
+
+
+variable_list = make_variable_list_by_categories(args.cat_list)
+#read data from sql database of obs counts
+df = utils.get_distinct_prepbufr_by_variable(variable_list)
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+df['category'] = df.apply(get_category, axis=1)
+
+df['date_only'] = df['datetime'].dt.date
+
+# Group by sensor and obs_day-- date only, summing obs_count
+grouped_df = df.groupby(['category', 'date_only'], as_index=False)['tot'].sum()
+
+# Convert obs_day to datetime if needed
+grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by=['category','date_only'])
+
+grouped_df['rolling_avg'] = grouped_df.groupby('category')['tot'].transform(lambda x: x.rolling(window=args.window, min_periods=1).mean())
+
+# Get unique sensors
+unique_categories = grouped_df['category'].unique()
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
+
+for category in unique_categories:
+    single_category_df = grouped_df[(grouped_df['category'] == category)]
+
+    ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
+
+ax.set_title(f'{args.title}', fontsize = 16)
+ax.set_xlabel('Observation Day', fontsize = 14)
+ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
+ax.set_yscale('log')  # log10 y-axis
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend(fontsize = 12)
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = f"conv_time_series_combo_avg_{args.window}_days.png"
+if args.dev:
+    file_name = f"conv_time_series_combo_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_conv_multiline.py
+++ b/src/plotting/plot_mysql_obs_count_conv_multiline.py
@@ -107,6 +107,7 @@ ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
+ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -81,7 +81,6 @@ ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -25,6 +25,7 @@ variable_dicts = {
     'pressure': {'PRESSURE'}, 
     'wind comp': {'WIND COMPONENTS'}, 
     'height': {'HEIGHT'},
+    'conv': {'TEMPERATURE', 'SPECIFIC HUMIDITY', 'PRESSURE', 'WIND COMPONENTS', 'HEIGHT'}
 }
 
 variable_titles = {
@@ -34,6 +35,7 @@ variable_titles = {
     'pressure': 'Conventional Pressure',
     'wind comp': 'Conventional Wind Components',
     'height': 'Conventional Height', 
+    'conv': 'Conventional Data',
 }
 
 
@@ -70,7 +72,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for var in unique_vars:
     single_var_df = grouped_df[(grouped_df['variable'] == var)]
 
-    ax.plot(single_var_df['date_only'], single_var_df['tot'])
+    ax.plot(single_var_df['date_only'], single_var_df['tot'],  label=f'{var}')
 
 ax.set_title(f'Time Series for {variable_titles[args.var]}')
 ax.set_xlabel('Observation Day')
@@ -84,7 +86,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-#ax.legend() #only need to add legend if we add variable names for multiple variables
+ax.legend() #only need to add legend if we add variable names for multiple variables
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -94,9 +94,9 @@ ax.legend() #only need to add legend if we add variable names for multiple varia
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
-file_name = f"{args.var}_conv_count_daily.png"
+file_name = f"{args.var}_conv_count_avg_{args.window}_days.png"
 if args.dev:
-    file_name = f"{args.var}_conv_count_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+    file_name = f"{args.var}_conv_count_avg_{args.window}_days_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
 fnout=os.path.join(args.out_dir,file_name)
 print(f"saving {fnout}")
 plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -43,10 +43,6 @@ variable_titles = {
 #parameters
 daterange=[date(1975,1,1), date(2026,1,1)]
 
-def plot_one_line(dftmp, yloc):
-    plt.plot(dftmp.datetime, yloc*dftmp.tot.astype('bool'),'|',color='black',markersize=5)
-
-
 #read data from sql database of obs counts
 df = utils.get_distinct_prepbufr_by_variable(variable_dicts[args.var])
 

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -70,7 +70,7 @@ grouped_df['rolling_avg'] = grouped_df['tot'].rolling(window=args.window, min_pe
 unique_vars = grouped_df['variable'].unique()
 
 # Create the plot
-fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+fig, ax = plt.subplots(figsize=(14, 8))  # Increase figure width
 
 #This handles if dictionaries are increased to have mulitple variables at once 
 for var in unique_vars:
@@ -78,19 +78,19 @@ for var in unique_vars:
 
     ax.plot(single_var_df['date_only'], single_var_df['rolling_avg'],  label=f'{var}')
 
-ax.set_title(f'Time Series for {variable_titles[args.var]}')
-ax.set_xlabel('Observation Day')
-ax.set_ylabel('Observation Count')
+ax.set_title(f'Time Series of {variable_titles[args.var]}', fontsize = 16)
+ax.set_xlabel('Observation Day', fontsize = 14)
+ax.set_ylabel('Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
-ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+#ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend() #only need to add legend if we add variable names for multiple variables
+ax.legend(fontsize = 12) #only need to add legend if we add variable names for multiple variables
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
 parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
 parser.add_argument("-variable", dest='var', help="Variable of conventional data to plot", type=str)
+parser.add_argument("-window", dest='window', help="Category of sensors to plot", type=int, default=1)
 args = parser.parse_args()
 
 variable_dicts = {
@@ -62,6 +63,9 @@ grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
 # Sort the grouped data
 grouped_df = grouped_df.sort_values(by='date_only')
 
+#Rolling average
+grouped_df['rolling_avg'] = grouped_df['tot'].rolling(window=args.window, min_periods=1).mean()
+
 # Get unique sensors
 unique_vars = grouped_df['variable'].unique()
 
@@ -72,7 +76,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for var in unique_vars:
     single_var_df = grouped_df[(grouped_df['variable'] == var)]
 
-    ax.plot(single_var_df['date_only'], single_var_df['tot'],  label=f'{var}')
+    ax.plot(single_var_df['date_only'], single_var_df['rolling_avg'],  label=f'{var}')
 
 ax.set_title(f'Time Series for {variable_titles[args.var]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -41,7 +41,7 @@ variable_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 #read data from sql database of obs counts
 df = utils.get_distinct_prepbufr_by_variable(variable_dicts[args.var])
@@ -78,6 +78,7 @@ ax.set_title(f'Time Series of {variable_titles[args.var]}', fontsize = 16)
 ax.set_xlabel('Observation Day', fontsize = 14)
 ax.set_ylabel('Daily Observation Count', fontsize = 14)
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 #ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -84,7 +84,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend()
+#ax.legend() #only need to add legend if we add variable names for multiple variables
 
 plt.tight_layout()
 plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -41,7 +41,7 @@ variable_titles = {
 daterange=[date(1975,1,1), date(2026,1,1)]
 
 def plot_one_line(dftmp, yloc):
-    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+    plt.plot(dftmp.datetime, yloc*dftmp.tot.astype('bool'),'|',color='black',markersize=5)
 
 
 #read data from sql database of obs counts
@@ -52,7 +52,7 @@ df['datetime'] = pd.to_datetime(df.obs_day)
 df['date_only'] = df['datetime'].dt.date
 
 # Group by sensor and obs_day-- date only, summing obs_count
-grouped_df = df.groupby(['variable', 'date_only'], as_index=False)['obs_count'].sum()
+grouped_df = df.groupby(['variable', 'date_only'], as_index=False)['tot'].sum()
 
 # Convert obs_day to datetime if needed
 grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
@@ -70,7 +70,7 @@ fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
 for var in unique_vars:
     single_var_df = grouped_df[(grouped_df['variable'] == var)]
 
-    ax.plot(single_var_df['date_only'], single_var_df['obs_count'])
+    ax.plot(single_var_df['date_only'], single_var_df['tot'])
 
 ax.set_title(f'Time Series for {variable_titles[args.var]}')
 ax.set_xlabel('Observation Day')

--- a/src/plotting/plot_mysql_obs_count_conv_var_daily.py
+++ b/src/plotting/plot_mysql_obs_count_conv_var_daily.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datetime import datetime, date
+import matplotlib.dates as mdates
+import os
+import argparse
+import plot_utils as utils
+import obs_inv_utils.inventory_table_factory as itf
+
+#argparse section
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", dest='out_dir', help="output directory for figures",default='figures',type=str)
+parser.add_argument("-dev", dest='dev', help='Use this flag to add a timestamp to the filename for development', default=False, type=bool)
+parser.add_argument("-variable", dest='var', help="Variable of conventional data to plot", type=str)
+args = parser.parse_args()
+
+variable_dicts = {
+    'temperature': {'TEMPERATURE'},
+    'spec humid': {'SPECIFIC HUMIDITY'},
+    'precip' : {'PRECIPITABLE H20'},
+    'pressure': {'PRESSURE'}, 
+    'wind comp': {'WIND COMPONENTS'}, 
+    'height': {'HEIGHT'},
+}
+
+variable_titles = {
+    'temperature': 'Conventional Temperature',
+    'spec humid': 'Conventional Specific Humidity',
+    'precip': 'Conventional Precipitable H20',
+    'pressure': 'Conventional Pressure',
+    'wind comp': 'Conventional Wind Components',
+    'height': 'Conventional Height', 
+}
+
+
+#parameters
+daterange=[date(1975,1,1), date(2026,1,1)]
+
+def plot_one_line(dftmp, yloc):
+    plt.plot(dftmp.datetime, yloc*dftmp.obs_count.astype('bool'),'|',color='black',markersize=5)
+
+
+#read data from sql database of obs counts
+df = utils.get_distinct_prepbufr_by_variable(variable_dicts[args.var])
+
+df['datetime'] = pd.to_datetime(df.obs_day)
+
+df['date_only'] = df['datetime'].dt.date
+
+# Group by sensor and obs_day-- date only, summing obs_count
+grouped_df = df.groupby(['variable', 'date_only'], as_index=False)['obs_count'].sum()
+
+# Convert obs_day to datetime if needed
+grouped_df['date_only'] = pd.to_datetime(grouped_df['date_only'])
+
+# Sort the grouped data
+grouped_df = grouped_df.sort_values(by='date_only')
+
+# Get unique sensors
+unique_vars = grouped_df['variable'].unique()
+
+# Create the plot
+fig, ax = plt.subplots(figsize=(14, 6))  # Increase figure width
+
+#This handles if dictionaries are increased to have mulitple variables at once 
+for var in unique_vars:
+    single_var_df = grouped_df[(grouped_df['variable'] == var)]
+
+    ax.plot(single_var_df['date_only'], single_var_df['obs_count'])
+
+ax.set_title(f'Time Series for {variable_titles[args.var]}')
+ax.set_xlabel('Observation Day')
+ax.set_ylabel('Observation Count')
+ax.set_yscale('log')  # log10 y-axis
+# Formatting the x-axis for dates (display only the year)
+ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
+ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
+plt.xticks(rotation=45, ha='right')
+
+# Add grid and legend
+ax.grid(True)
+ax.legend()
+
+plt.tight_layout()
+plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)
+file_name = f"{args.var}_conv_count_daily.png"
+if args.dev:
+    file_name = f"{args.var}_conv_count_daily_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+fnout=os.path.join(args.out_dir,file_name)
+print(f"saving {fnout}")
+plt.savefig(fnout, bbox_inches='tight')

--- a/src/plotting/plot_mysql_wod_obs_count_daily.py
+++ b/src/plotting/plot_mysql_wod_obs_count_daily.py
@@ -33,7 +33,7 @@ variable_titles = {
 
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 #read data from sql database of obs counts
 df = utils.get_wod_nc_by_variable(variable_dicts[args.var])
@@ -70,6 +70,7 @@ ax.set_title(f'Time Series for {variable_titles[args.var]}')
 ax.set_xlabel('Observation Day')
 ax.set_ylabel('Observation Count')
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator())  # Major ticks every year
 ax.xaxis.set_minor_locator(mdates.MonthLocator())  # Minor ticks every month

--- a/src/plotting/plot_mysql_wod_obs_count_multiline.py
+++ b/src/plotting/plot_mysql_wod_obs_count_multiline.py
@@ -98,6 +98,7 @@ ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))  # Format major ticks as years
 plt.xticks(rotation=45, ha='right')
+ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)

--- a/src/plotting/plot_mysql_wod_obs_count_multiline.py
+++ b/src/plotting/plot_mysql_wod_obs_count_multiline.py
@@ -33,7 +33,7 @@ category_titles = {
 }
 
 #parameters
-daterange=[date(1975,1,1), date(2026,1,1)]
+daterange=[date(1979,1,1), date(2026,1,1)]
 
 def select_variable(variable, db_frame):
     dftmp = db_frame.loc[db_frame['variable']==variable]
@@ -88,10 +88,11 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 16)
-ax.set_xlabel('Observation Day', fontsize = 14)
-ax.set_ylabel('Average Daily Observation Count', fontsize = 14)
+ax.set_title(f'{args.title}', fontsize = 20) #16
+ax.set_xlabel('Observation Day', fontsize = 18) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
 ax.set_yscale('log')  # log10 y-axis
+ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
 ax.xaxis.set_major_locator(mdates.YearLocator(5))  # Major ticks every 5 years
 ax.xaxis.set_minor_locator(mdates.YearLocator())  # Minor ticks every year
@@ -100,7 +101,7 @@ plt.xticks(rotation=45, ha='right')
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 11)
+ax.legend(fontsize = 15) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_mysql_wod_obs_count_multiline.py
+++ b/src/plotting/plot_mysql_wod_obs_count_multiline.py
@@ -88,9 +88,9 @@ for category in unique_categories:
 
     ax.plot(single_category_df['date_only'], single_category_df['rolling_avg'], label=f'{category_titles[category]}')
 
-ax.set_title(f'{args.title}', fontsize = 20) #16
-ax.set_xlabel('Observation Day', fontsize = 18) #14
-ax.set_ylabel('Average Daily Observation Count', fontsize = 18) #14
+ax.set_title(f'{args.title}', fontsize = 18) #16
+ax.set_xlabel('Observation Day', fontsize = 17) #14
+ax.set_ylabel('Average Daily Observation Count', fontsize = 17) #14
 ax.set_yscale('log')  # log10 y-axis
 ax.set_xlim(daterange)
 # Formatting the x-axis for dates (display only the year)
@@ -102,7 +102,7 @@ ax.tick_params(labelsize=12)
 
 # Add grid and legend
 ax.grid(True)
-ax.legend(fontsize = 15) #11
+ax.legend(fontsize = 12) #11
 
 plt.tight_layout()
 # plt.suptitle(f'accurate as of {datetime.now().strftime("%m/%d/%Y %H:%M:%S")} UTC', y=-0.01)

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -617,3 +617,45 @@ def get_distinct_prepbufr_by_variable(var_list):
     session.close()
 
     return df
+
+def get_ioda_nc_by_sensor(sensor_list):
+    session = itf.Session()
+    query = session.query(
+        omhin.variable,
+        omhin.num_locs,
+        omhin.sensor,
+        omhin.obs_day,
+        omhin.ioda_version,
+        oi.parent_dir
+    ).join(
+        oi,
+        omhin.obs_id == oi.obs_id
+    ).filter(
+        oi.s3_bucket == 'noaa-reanalyses-pds'
+    )
+
+    if sensor_list:
+        sensor_filters = [oi.parent_dir.like(f"{sensor}%") for sensor in sensor_list]
+        query = query.filter(or_(*sensor_filters))
+
+    results = query.all()
+
+    result_dicts = [
+        {
+            'variable': result.variable,
+            'var_count': result.num_locs,
+            'sensor': result.sensor,
+            'obs_day': result.obs_day,
+            'ioda_version': result.ioda_version,
+            'parent_dir': result.parent_dir
+        }
+        for result in results
+    ]
+
+    # Convert the list of dictionaries to a pandas DataFrame
+    df = pandas.DataFrame(result_dicts)
+
+    # Close the session
+    session.close()
+
+    return df

--- a/src/plotting/plot_utils.py
+++ b/src/plotting/plot_utils.py
@@ -472,7 +472,7 @@ def get_distinct_prepbufr_by_typ_variable(typ_list, var_list):
     if var_list is None:
         return get_distinct_prepbufr_by_typ(typ_list) #no variables, just use typ list
     if typ_list is None: 
-        return get_distinct_prepbufr() #return all values since no variable only options right now
+        return get_distinct_prepbufr_by_variable(var_list) #return all values since no variable only options right now
 
     session = itf.Session()
     # Subquery to get the most recent inserted_at for each combination of other columns
@@ -515,6 +515,78 @@ def get_distinct_prepbufr_by_typ_variable(typ_list, var_list):
     ).filter(
         oi.s3_bucket == 'noaa-reanalyses-pds',
         omnp.typ.in_(typ_list), #filter by typ_list
+        omnp.variable.in_(var_list)
+    )
+
+    # Execute the query
+    results = query.all()
+
+    # Convert results to a list of dictionaries
+    result_dicts = [
+        {
+            'obs_id': result.obs_id,
+            'variable': result.variable,
+            'typ': result.typ,
+            'tot': result.tot,
+            'qm0thru3': result.qm0thru3,
+            'filename': result.filename,
+            'file_size': result.file_size,
+            'obs_day': result.obs_day,
+            'parent_dir': result.parent_dir,
+            's3_bucket': result.s3_bucket
+        }
+        for result in results
+    ]
+
+    # Convert the list of dictionaries to a pandas DataFrame
+    df = pandas.DataFrame(result_dicts)
+
+    # Close the session
+    session.close()
+
+    return df
+
+def get_distinct_prepbufr_by_variable(var_list):
+    session = itf.Session()
+    # Subquery to get the most recent inserted_at for each combination of other columns
+    subquery = session.query(
+        omnp.obs_id,
+        omnp.variable,
+        omnp.typ,
+        omnp.tot,
+        omnp.qm0thru3,
+        omnp.filename,
+        omnp.file_size,
+        omnp.obs_day,
+        func.max(omnp.inserted_at).label('max_inserted_at')
+    ).group_by(
+        omnp.obs_id,
+        omnp.variable,
+        omnp.typ,
+        omnp.tot,
+        omnp.qm0thru3,
+        omnp.filename,
+        omnp.file_size,
+        omnp.obs_day
+    ).subquery()
+
+    # Join the subquery with the main table to get the full records
+    query = session.query(omnp.obs_id, omnp.variable, omnp.typ, omnp.tot, omnp.qm0thru3, omnp.filename, omnp.file_size, omnp.obs_day, oi.parent_dir, oi.s3_bucket).join(
+        subquery,
+        (omnp.obs_id == subquery.c.obs_id) &
+        (omnp.variable == subquery.c.variable) &
+        (omnp.typ == subquery.c.typ) &
+        (omnp.tot == subquery.c.tot) &
+        (omnp.qm0thru3 == subquery.c.qm0thru3) &
+        (omnp.filename == subquery.c.filename) &
+        (omnp.file_size == subquery.c.file_size) &
+        (omnp.obs_day == subquery.c.obs_day) &
+        (omnp.inserted_at == subquery.c.max_inserted_at)
+    ).join(
+        oi,
+        omnp.obs_id == oi.obs_id
+    ).filter(
+        oi.s3_bucket == 'noaa-reanalyses-pds',
         omnp.variable.in_(var_list)
     )
 


### PR DESCRIPTION
This PR adds the capability of plotting the actual observation counts in a variety of ways including individual streams or in combinations of categories on the same or different plots. The plots are all operating on a log based axis. As part of the new functionality, this adds a couple new plot util functions for pulling the data. 

A few example graphics generated from this code:
![atm_time_series_combo_avg_90_days_20250618002637](https://github.com/user-attachments/assets/70ac1307-c8de-426e-aff1-9f806a68c7c8)
![conv_time_series_combo_avg_90_days_20250618004204](https://github.com/user-attachments/assets/3468d998-982f-4bec-bbe9-23f44c403b88)
![ice_time_series_combo_avg_90_days_20250618003107](https://github.com/user-attachments/assets/275d77dc-15ae-44e9-9491-85167f0af758)
