### PR TITLE
Feature: Add tables for simple ozone nc files 

### DIFF
--- a/src/config_handlers/obs_meta_ozone_nc.py
+++ b/src/config_handlers/obs_meta_ozone_nc.py
@@ -66,7 +66,7 @@ class ObsMetaOzoneConfig(ConfigInterface):
             date_range)
 
         self.ozone_files = self.yaml_loader.get_value(
-            key='wod_files',
+            key='ozone_files',
             document=self.config_data,
             return_type=list
         )

--- a/src/config_handlers/obs_meta_ozone_nc.py
+++ b/src/config_handlers/obs_meta_ozone_nc.py
@@ -1,0 +1,90 @@
+import os
+
+from dataclasses import dataclass, field
+from obs_inv_utils.config_base import ConfigInterface
+from obs_inv_utils.yaml_utils import YamlLoader
+from obs_inv_utils import time_utils
+from obs_inv_utils.time_utils import DateRange
+
+HV_OZONE_META_NC = 'hv_ozone_meta_nc'
+
+@dataclass
+class ObsMetaOzoneConfig(ConfigInterface):
+    """
+    Function to load config data for observation meta data 
+    stored in ioda that will be harvested using score-hv
+    """
+    config_yaml: str
+    config_data: dict = field(default_factory=str, init=False)
+    s3_bucket: str = field(default_factory=str, init=False)
+    s3_prefix: str = field(default_factory=str, init=False)
+    ozone_files: list = field(default_factory=list, init=False)
+    work_dir: str = field(default_factory=str, init=False)
+    scrub_files: bool = field(default_factory=bool, init=False)
+    date_range: DateRange = field(
+        default_factory=DateRange, init=False)
+
+    def __post_init__(self):
+
+        super().__init__(self.config_yaml)
+
+    def __repr__(self):
+        """
+        string representation of config_yaml and config_data
+        """
+        return f'config_yaml: {self.config_yaml}, ' \
+            f'config_data: {self.config_data}, ' \
+            f's3_bucket: {self.s3_bucket}, ' \
+            f'date_range: {self.date_range}, ' \
+            f'ozone_files: {self.ozone_files}, '
+
+
+    def load(self):
+        self.config_data = self.yaml_loader.load()
+        self.parse()
+
+    def parse(self):        
+        self.s3_bucket = self.yaml_loader.get_value(
+            key='s3_bucket',
+            document=self.config_data,
+            return_type=str
+        )
+
+        self.s3_prefix = self.yaml_loader.get_value(
+            key='s3_prefix',
+            document=self.config_data,
+            return_type=str
+        )
+
+        date_range = self.yaml_loader.get_value(
+            key='date_range',
+            document=self.config_data,
+            return_type=dict
+        )
+        
+        self.date_range = time_utils.get_date_range_from_dict(
+            date_range)
+
+        self.ozone_files = self.yaml_loader.get_value(
+            key='wod_files',
+            document=self.config_data,
+            return_type=list
+        )
+
+        self.work_dir = self.yaml_loader.get_value(
+            key='work_dir',
+            document=self.config_data,
+            return_type=str
+        )
+
+        self.scrub_files = self.yaml_loader.get_value(
+            key='scrub_files',
+            document=self.config_data,
+            return_type=bool
+        )
+
+    def get_date_range(self):
+        return self.date_range
+
+    def get_ozone_file_list(self):
+        return self.ozone_files

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -27,6 +27,7 @@ OBS_META_HV_IODA_NETCDF_TABLE = 'obs_meta_hv_ioda_netcdf'
 OBS_META_HV_IODA_NETCDF_AGG_TABLE = 'obs_meta_hv_ioda_netcdf_aggregate'
 OBS_META_HV_WOD_NETCDF_TABLE = 'obs_meta_hv_wod_netcdf'
 OBS_META_HV_WOD_NETCDF_AGG_TABLE = 'obs_meta_hv_wod_netcdf_aggregate'
+OBS_META_HV_OZONE_NETCDF_TABLE = 'obs_meta_hv_ozone_netcdf'
 OBS_DATABASE = ''
 OBS_SQLITE_DEFAULT = 'observations_inventory.db'
 
@@ -478,6 +479,49 @@ def create_obs_meta_hv_wod_netcdf_agg_table():
             )
         )
 
+def create_obs_meta_hv_ozone_netcdf_table():
+    insp = inspect(engine)
+    table_exists = insp.has_table(OBS_META_HV_OZONE_NETCDF_TABLE)
+    print(f'{OBS_META_HV_OZONE_NETCDF_TABLE} table exists: {table_exists}')
+    if not insp.has_table(OBS_META_HV_OZONE_NETCDF_TABLE):
+
+        Table(OBS_META_HV_OZONE_NETCDF_TABLE, metadata,
+              Column('meta_id', Integer, primary_key=True),
+              Column(
+                  'obs_id',
+                  Integer,
+                  ForeignKey('obs_inventory.obs_id'),
+                  nullable=False
+              ),
+              Column(
+                  'cmd_result_id',
+                  Integer,
+                  ForeignKey('cmd_results.cmd_result_id'),
+                  nullable=False
+              ),
+              Column('cmd_str', String),
+              Column('variable', String),
+              Column('ozone_count', Integer),
+              Column('levels', Integer),
+              Column('profiles', Integer),
+              Column('min_pressure', Float),
+              Column('max_pressure', Float),
+              Column('sensor', String),
+              Column('filename', String),
+              Column('min_data_date', DateTime),
+              Column('max_data_date', DateTime),
+              Column('obs_day', DateTime),
+              Column('inserted_at', DateTime),
+              UniqueConstraint(
+                'obs_id',
+                'ozone_count',
+                'levels',
+                'filename',
+                'obs_day',
+                name='unique_ozone_nc_meta'
+            )
+        )
+
 class CmdResult(Base):
     __tablename__ = CMD_RESULTS_TABLE
 
@@ -783,6 +827,38 @@ class ObsMetaHvWodNetcdfAggregate(Base):
     min_data_date = Column(DateTime())
     max_data_date = Column(DateTime())
     obs_day = Column(DateTime())
+    inserted_at = Column(DateTime())
+
+    cmd_result = relationship("CmdResult", foreign_keys=[cmd_result_id])
+
+class ObsMetaHvOzoneNetcdf(Base):
+    __tablename__ = OBS_META_HV_OZONE_NETCDF_TABLE
+    __table_args__ = (
+        UniqueConstraint(
+            'obs_id',
+            'ozone_count',
+            'levels',
+            'filename',
+            'obs_day',
+            name='unique_ozone_nc_meta'
+        ),
+    )
+
+    meta_id = Column(Integer, primary_key=True)
+    obs_id = Column(Integer, ForeignKey('obs_inventory.obs_id'))
+    cmd_result_id = Column(Integer, ForeignKey('cmd_results.cmd_result_id'))
+    cmd_str = Column(String(31))
+    variable = Column(String(63))
+    ozone_count = Column(Integer())
+    levels = Column(Integer())
+    profiles = Column(Integer())
+    min_pressure = Column(Float())
+    max_pressure = Column(Float())
+    sensor = Column(String(63))
+    filename = Column(String(63))
+    min_data_date = Column(DateTime())
+    max_data_date = Column(DateTime())
+    obs_day = Column(DateTime()) 
     inserted_at = Column(DateTime())
 
     cmd_result = relationship("CmdResult", foreign_keys=[cmd_result_id])
@@ -1362,6 +1438,72 @@ def insert_obs_meta_hv_wod_netcdf_agg_item(obs_meta_items, max_retries=3, backof
     if inserted_count == 0:
         print("NO DATA PROVIDED TO INSERT. No data inserted into the wod netcdf aggregate meta table.")
 
+
+def insert_obs_meta_hv_ozone_netcdf_item(obs_meta_items, max_retries=3, backoff_delay=0.2):
+    if not isinstance(obs_meta_items, list):
+        msg = 'Inserted obs meta ozone NetCDF items must be in the form of a list.' \
+              f' Received type: {type(obs_meta_items)}'
+        raise TypeError(msg)
+
+
+    # SQL statement with INSERT/IGNORE or INSERT OR IGNORE depending on database type
+    if(database_type.lower() == 'mysql'):
+        sql = """
+            INSERT IGNORE INTO obs_meta_hv_ozone_netcdf
+            (obs_id, cmd_result_id, cmd_str, variable, ozone_count, levels, profiles, min_pressure, max_pressure,
+            sensor, casts, filename, min_data_date, max_data_date, obs_day, inserted_at)
+            VALUES (:obs_id, :cmd_result_id, :cmd_str, :variable, :ozone_count, :levels, :profiles, :min_pressure, :max_pressure, 
+            :sensor, :filename, :min_data_date, :max_data_date, :obs_day, :inserted_at)
+        """
+    else:
+        sql = """
+            INSERT OR IGNORE INTO obs_meta_hv_ozone_netcdf
+            (obs_id, cmd_result_id, cmd_str, variable, ozone_count, levels, profiles, min_pressure, max_pressure, 
+            sensor, casts, filename, min_data_date, max_data_date, obs_day, inserted_at)
+            VALUES (:obs_id, :cmd_result_id, :cmd_str, :variable, :ozone_count, :levels, :profiles, :min_pressure, :max_pressure, 
+            :sensor, :filename, :min_data_date, :max_data_date, :obs_day, :inserted_at)
+        """
+
+    session = Session()
+    inserted_count = 0
+
+    for item in obs_meta_items:
+        row = {
+            'obs_id': item.obs_id,
+            'cmd_result_id': item.cmd_result_id,
+            'cmd_str': item.cmd_str,
+            'variable': item.variable,
+            'ozone_count': item.ozone_count,
+            'levels': item.levels,
+            'profiles': item.profiles,
+            'min_pressure': item.min_pressure,
+            'max_pressure': item.max_pressure,
+            'sensor': item.sensor,
+            'filename': item.filename,
+            'min_data_date': item.min_data_date,
+            'max_data_date': item.max_data_date,
+            'obs_day': item.obs_day.strftime('%Y-%m-%d %H:%M:%S'),
+            'inserted_at': datetime.utcnow()
+        }
+
+        for attempt in range(max_retries):
+            try:
+                session.execute(text(sql), row)
+                session.commit()
+                inserted_count += 1
+                break
+            except OperationalError as e:
+                session.rollback()
+                if '1213' in str(e): #MySQL deadlock
+                    time.sleep(backoff_delay * (attempt + 1))
+                else:
+                    session.close()
+                    raise
+
+    session.close()
+    if inserted_count == 0:
+        print("NO DATA PROVIDED TO INSERT. No data inserted into the ozone netcdf meta table.")
+
 if(database_type.lower() == 'mysql'):
     Base.metadata.create_all(engine)
 else:
@@ -1374,4 +1516,5 @@ else:
     create_obs_meta_hv_ioda_netcdf_agg_table()
     create_obs_meta_hv_wod_netcdf_table()
     create_obs_meta_hv_wod_netcdf_agg_table()
+    create_obs_meta_hv_ozone_netcdf_table()
     metadata.create_all(engine)

--- a/src/obs_inv_utils/inventory_table_factory.py
+++ b/src/obs_inv_utils/inventory_table_factory.py
@@ -1451,7 +1451,7 @@ def insert_obs_meta_hv_ozone_netcdf_item(obs_meta_items, max_retries=3, backoff_
         sql = """
             INSERT IGNORE INTO obs_meta_hv_ozone_netcdf
             (obs_id, cmd_result_id, cmd_str, variable, ozone_count, levels, profiles, min_pressure, max_pressure,
-            sensor, casts, filename, min_data_date, max_data_date, obs_day, inserted_at)
+            sensor, filename, min_data_date, max_data_date, obs_day, inserted_at)
             VALUES (:obs_id, :cmd_result_id, :cmd_str, :variable, :ozone_count, :levels, :profiles, :min_pressure, :max_pressure, 
             :sensor, :filename, :min_data_date, :max_data_date, :obs_day, :inserted_at)
         """
@@ -1459,7 +1459,7 @@ def insert_obs_meta_hv_ozone_netcdf_item(obs_meta_items, max_retries=3, backoff_
         sql = """
             INSERT OR IGNORE INTO obs_meta_hv_ozone_netcdf
             (obs_id, cmd_result_id, cmd_str, variable, ozone_count, levels, profiles, min_pressure, max_pressure, 
-            sensor, casts, filename, min_data_date, max_data_date, obs_day, inserted_at)
+            sensor, filename, min_data_date, max_data_date, obs_day, inserted_at)
             VALUES (:obs_id, :cmd_result_id, :cmd_str, :variable, :ozone_count, :levels, :profiles, :min_pressure, :max_pressure, 
             :sensor, :filename, :min_data_date, :max_data_date, :obs_day, :inserted_at)
         """

--- a/src/obs_inv_utils/obs_inv_cli.py
+++ b/src/obs_inv_utils/obs_inv_cli.py
@@ -24,7 +24,7 @@ from config_handlers.obs_meta_cmpbqm import ObsMetaCMPBQMConfig
 from config_handlers.obs_meta_ioda import ObsMetaIodaConfig
 from config_handlers.obs_meta_wod import ObsMetaWodConfig
 from config_handlers.obs_meta_ozone_nc import ObsMetaOzoneConfig
-from config_handlers import obs_meta_sinv, obs_meta_cmpbqm, obs_meta_ioda, obs_meta_wod
+from config_handlers import obs_meta_sinv, obs_meta_cmpbqm, obs_meta_ioda, obs_meta_wod, obs_meta_ozone_nc
 from obs_inv_utils.nceplibs_bufr_cmd_handler import ObsBufrFileMetaHandler, ObsPrepBufrFileMetaHandler
 from obs_inv_utils.score_hv_netcdf_cmd_handler import ObsIodaFileMetaHandler, ObsWODFileMetaHandler, ObsOzoneFileMetaHandler
 
@@ -113,7 +113,7 @@ def get_obs_count_meta_ozone_hv_base(config_yaml):
     config.load()
     print(repr(config))
     mh = ObsOzoneFileMetaHandler(config)
-    mh.get_ozone_file_meta(obs_meta_wod.HV_OZONE_META)
+    mh.get_ozone_file_meta(obs_meta_ozone_nc.HV_OZONE_META)
 
 @cli.command()
 @click.option('-c', '--config-yaml', 'config_yaml', required=True, type=str)

--- a/src/obs_inv_utils/obs_inv_cli.py
+++ b/src/obs_inv_utils/obs_inv_cli.py
@@ -23,9 +23,10 @@ from config_handlers.obs_meta_sinv import ObsMetaSinvConfig
 from config_handlers.obs_meta_cmpbqm import ObsMetaCMPBQMConfig
 from config_handlers.obs_meta_ioda import ObsMetaIodaConfig
 from config_handlers.obs_meta_wod import ObsMetaWodConfig
+from config_handlers.obs_meta_ozone_nc import ObsMetaOzoneConfig
 from config_handlers import obs_meta_sinv, obs_meta_cmpbqm, obs_meta_ioda, obs_meta_wod
 from obs_inv_utils.nceplibs_bufr_cmd_handler import ObsBufrFileMetaHandler, ObsPrepBufrFileMetaHandler
-from obs_inv_utils.score_hv_netcdf_cmd_handler import ObsIodaFileMetaHandler, ObsWODFileMetaHandler
+from obs_inv_utils.score_hv_netcdf_cmd_handler import ObsIodaFileMetaHandler, ObsWODFileMetaHandler, ObsOzoneFileMetaHandler
 
 from obs_inv_utils import plot_generator as pg
 from obs_inv_utils import search_engine as se
@@ -106,6 +107,18 @@ def get_obs_count_meta_wod_hv_base(config_yaml):
 @click.option('-c', '--config-yaml', 'config_yaml', required=True, type=str)
 def get_obs_count_meta_wod_hv(config_yaml):
     return get_obs_count_meta_wod_hv_base(config_yaml)
+
+def get_obs_count_meta_ozone_hv_base(config_yaml):
+    config = ObsMetaOzoneConfig(config_yaml)
+    config.load()
+    print(repr(config))
+    mh = ObsOzoneFileMetaHandler(config)
+    mh.get_ozone_file_meta(obs_meta_wod.HV_OZONE_META)
+
+@cli.command()
+@click.option('-c', '--config-yaml', 'config_yaml', required=True, type=str)
+def get_obs_count_meta_ozone_hv(config_yaml):
+    return get_obs_count_meta_ozone_hv_base(config_yaml)
     
 
 if __name__ == '__main__':

--- a/src/obs_inv_utils/obs_inv_cli.py
+++ b/src/obs_inv_utils/obs_inv_cli.py
@@ -113,7 +113,7 @@ def get_obs_count_meta_ozone_hv_base(config_yaml):
     config.load()
     print(repr(config))
     mh = ObsOzoneFileMetaHandler(config)
-    mh.get_ozone_file_meta(obs_meta_ozone_nc.HV_OZONE_META)
+    mh.get_ozone_file_meta(obs_meta_ozone_nc.HV_OZONE_META_NC)
 
 @cli.command()
 @click.option('-c', '--config-yaml', 'config_yaml', required=True, type=str)

--- a/src/obs_inv_utils/score_hv_cmd_ozone_nc.py
+++ b/src/obs_inv_utils/score_hv_cmd_ozone_nc.py
@@ -1,0 +1,86 @@
+from collections import namedtuple
+
+from obs_inv_utils import score_hv_cmds
+from obs_inv_utils import inventory_table_factory as itf
+
+OZONE_META_NETCDF = 'ozone_meta_netcdf'
+
+ObsMetaOzoneData = namedtuple(
+    'ObsMetaOzoneData',
+    [
+        'obs_id',
+        'cmd_result_id',
+        'cmd_str',
+        'variable', #will always be ozone, but want for consistency with other tables
+        'ozone_count',
+        'levels',
+        'profiles',
+        'min_pressure',
+        'max_pressure',
+        'sensor',
+        'filename',
+        'min_data_date',
+        'max_data_date',
+        'obs_day',
+    ]
+)
+
+def build_harvest_dict(command, args):
+    filename = args.get('filename', None)
+    if filename is None: 
+        raise ValueError('required args "filename" not found. cannot build harvest dict')
+    hv_dict =  {
+        'harvester_name': command,
+        'filename': filename
+    }
+    return hv_dict
+
+def post_harvest_results(cmd_id, harvest_response, ozone_file):
+    #go through response, if multiple variables insert each individually and then insert an agg value
+    if not isinstance(harvest_response, list):
+        print(f'Error posting harvest results as the response is not of type list but {type(harvest_response)}')
+        return #can't parse if not a list of objects
+    
+    obs_meta_data_items = []
+    
+    #go through items in harvest response and build data insert 
+    for item in harvest_response:
+        new_item = ObsMetaOzoneData(
+            ozone_file.obs_id, 
+            cmd_id,
+            score_hv_cmds.HV_OZONE_NC_META,
+            'ozone',
+            convert_to_int(item.ozone_count),
+            convert_to_int(item.levels),
+            convert_to_int(item.profiles), 
+            convert_to_float(item.min_pressure),
+            convert_to_float(item.max_pressure),
+            item.sensor,
+            item.filename,
+            item.min_date_time,
+            item.max_date_time,
+            ozone_file.obs_day
+        )
+
+        obs_meta_data_items.append(new_item)
+
+    #once all items have been translated to work with columns, insert to correct tables 
+    itf.insert_obs_meta_hv_ozone_netcdf_item(obs_meta_data_items)
+
+def convert_to_int(value):
+    """Safely convert a value to an int."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+def convert_to_float(value):
+    """Safely convert a value to a float."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None

--- a/src/obs_inv_utils/score_hv_cmds.py
+++ b/src/obs_inv_utils/score_hv_cmds.py
@@ -1,9 +1,11 @@
 from obs_inv_utils.score_hv_cmd_handler import ScoreHVCmd
 from obs_inv_utils import score_hv_cmd_ioda
 from obs_inv_utils import score_hv_cmd_wod_nc
+from obs_inv_utils import score_hv_cmd_ozone_nc
 
 HV_IODA_META = 'ioda_meta_netcdf'
 HV_WOD_NC_META = 'wod_insitu_meta_netcdf'
+HV_OZONE_NC_META = 'ozone_meta_netcdf'
 
 score_hv_cmds = {
     HV_IODA_META: ScoreHVCmd(
@@ -15,5 +17,10 @@ score_hv_cmds = {
         HV_WOD_NC_META,
         score_hv_cmd_wod_nc.build_harvest_dict,
         score_hv_cmd_wod_nc.post_harvest_results
+    ),
+    HV_OZONE_NC_META: ScoreHVCmd(
+        HV_OZONE_NC_META,
+        score_hv_cmd_ozone_nc.build_harvest_dict,
+        score_hv_cmd_ozone_nc.post_harvest_results
     )
 }

--- a/src/obs_inv_utils/score_hv_netcdf_cmd_handler.py
+++ b/src/obs_inv_utils/score_hv_netcdf_cmd_handler.py
@@ -13,6 +13,8 @@ import pathlib
 import numpy as np
 
 from config_handlers.obs_meta_ioda import ObsMetaIodaConfig
+from config_handlers.obs_meta_wod import ObsMetaWodConfig
+from config_handlers.obs_meta_ozone_nc import ObsMetaOzoneConfig
 from obs_inv_utils import obs_inv_queries as oiq
 from obs_inv_utils import aws_s3_interface as s3
 from obs_inv_utils import time_utils
@@ -142,7 +144,7 @@ class ObsIodaFileMetaHandler(object):
 
 @dataclass
 class ObsWODFileMetaHandler(object):
-    meta_config: ObsMetaIodaConfig
+    meta_config: ObsMetaWodConfig
     wod_files: list = field(default_factory=list, init=False)
     date_range: DateRange = field(init=False)
 
@@ -194,3 +196,55 @@ class ObsWODFileMetaHandler(object):
         cmd.post_harvest_results(wod_file)
 
 
+@dataclass
+class ObsOzoneFileMetaHandler(object):
+    meta_config: ObsMetaOzoneConfig
+    ozone_files: list = field(default_factory=list, init=False)
+    date_range: DateRange = field(init=False)
+
+    def __post_init__(self):
+        self.date_range = self.meta_config.get_date_range()
+        self.ozone_files = self.meta_config.get_ozone_file_list()
+
+    def __repr__(self):
+        return f'meta_config: {self.meta_config}, ' \
+            f'ozone_files: {self.ozone_files}, ' \
+            f'date_range: {self.date_range}'
+    
+    def get_ozone_file_meta(self, cmd_type):
+        inventory_ozone_files = oiq.get_files_data(
+            self.ozone_files,
+            self.date_range.start,
+            self.date_range.end
+        )
+
+        temp_uuid = str(uuid.uuid4())
+
+        work_dir = os.path.join(self.meta_config.work_dir, temp_uuid)
+
+        for idx, ozone_file in inventory_ozone_files.iterrows():
+            file_downloaded = False
+
+            saved_filename = download_netcdf_file_from_s3(work_dir, ozone_file)
+
+            if saved_filename is None:
+                continue
+
+            self.get_obs_meta_with_hv_ozone(saved_filename, ozone_file)
+
+            # clean up files
+            if self.meta_config.scrub_files:
+                shutil.rmtree( work_dir )
+
+
+    def get_obs_meta_with_hv_ozone(self, filename, ozone_file):
+        args = {'filename': filename}
+        cmd = cmhd.ScoreHVCmdHandler(
+            hv_cmds.HV_OZONE_NC_META,
+            hv_cmds.score_hv_cmds,
+            args
+        )
+
+        cmd.harvest()
+        cmd.post_cmd_result(ozone_file.obs_day)
+        cmd.post_harvest_results(ozone_file)

--- a/src/obs_inv_utils/search_engine.py
+++ b/src/obs_inv_utils/search_engine.py
@@ -256,6 +256,14 @@ def parse_filename_regex(filename):
             r'(?P<date_time>\d{4}-\d{2}-\d{2})T(?P<cycle_hour>\d{2})'
             r'\.(?P<data_format>[^.]+)$'
         ),
+        # Underscore-separated cycle tag (e.g., OMPSNP.20230925_12z.nc)
+        re.compile(
+            r'^(?P<prefix>.+?)\.'
+            r'(?P<date_time>\d{8})_'
+            r'(?P<cycle_tag>\d{2}z)\.'
+            r'(?P<data_format>[^.]+)'
+            r'(?:\.(?P<not_restricted_tag>nr))?$'
+        )
     ]
 
     for pattern in patterns:


### PR DESCRIPTION
This PR adds a new inventory table for ozone files stored in generic netcdf format to expand the capability of our inventory to include the complete ozone picture instead of just bufr stored data. The tables are built to reflect the specific types of metadata available within these files. For enabling ease of use in future plotting, a variable column is included even though the variable is always ozone. 

A new pattern for the search engine has been added to address the datetime format the filenames are using. This reflects a standardization used by NASA instead of NOAA. 

This table has been tested via the test database with the latest score-hv branch (with a necessary change to handle empty files) successfully. 

Given these files only contain the specific ozone variable, there is no reason to include an aggregate table as it would simply be a duplication of data. 