### PR TITLE
Add new ADT dicts for GLORe data

### DIFF
--- a/src/automation/ocn_dicts.py
+++ b/src/automation/ocn_dicts.py
@@ -13,6 +13,18 @@ adt_GLORe_cryosat2_v3 = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
+adt_GLORe_ers2_v3 = InventoryInfo(
+    obs_name='adt_GLORe_ers2_v3',
+    key='observations/reanalysis/adt/GLORe/ers2/%Y/%m/iodav3/adt.e2.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='19950516T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/ers2/%Y/%m/iodav3/',
+    files='adt.e2.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
 adt_GLORe_GFO_v3 = InventoryInfo(
     obs_name='adt_GLORe_GFO_v3',
     key='observations/reanalysis/adt/GLORe/GFO/%Y/%m/iodav3/adt.g1.%Y%m%d.T%H%M%SZ.iodav3.nc',
@@ -61,6 +73,18 @@ adt_GLORe_jason3_v3 = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET,
 )
 
+adt_GLORe_n1_v3 = InventoryInfo(
+    obs_name='adt_GLORe_n1_v3',
+    key='observations/reanalysis/adt/GLORe/n1/%Y/%m/iodav3/adt.n1.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20020828T180000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/n1/%Y/%m/iodav3/',
+    files='adt.n1.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
 adt_GLORe_saral_v3 = InventoryInfo(
     obs_name='adt_GLORe_saral_v3',
     key='observations/reanalysis/adt/GLORe/saral/%Y/%m/iodav3/adt.sa.%Y%m%d.T%H%M%SZ.iodav3.nc',
@@ -103,6 +127,18 @@ adt_GLORe_sentinel6a_v3 = InventoryInfo(
     start='20220111T000000Z',
     s3_prefix='observations/reanalysis/adt/GLORe/sentinel6a/%Y/%m/iodav3/',
     files='adt.6a.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_swot_v3 = InventoryInfo(
+    obs_name='adt_GLORe_swot_v3',
+    key='observations/reanalysis/adt/GLORe/swot/%Y/%m/iodav3/adt.sw.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20240101T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/swot/%Y/%m/iodav3/',
+    files='adt.sw.%z.iodav3.nc',
     inv_cmd=au.HV_IODA_META,
     platform=au.CLEAN_PLATFORM,
     cycling_interval=au.CYCLING_6H,

--- a/src/automation/ocn_dicts.py
+++ b/src/automation/ocn_dicts.py
@@ -1009,8 +1009,8 @@ insitu_wod_xbt = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET
 )
 
-ocn_infos = [adt_GLORe_cryosat2_v3, adt_GLORe_GFO_v3, adt_GLORe_jason1_v3, adt_GLORe_jason2_v3, adt_GLORe_jason3_v3, adt_GLORe_saral_v3,
-             adt_GLORe_sentinel3a_v3, adt_GLORe_sentinel3b_v3, adt_GLORe_sentinel6a_v3, adt_GLORe_topex_poseidon_v3, 
+ocn_infos = [adt_GLORe_cryosat2_v3, adt_GLORe_ers2_v3, adt_GLORe_GFO_v3, adt_GLORe_jason1_v3, adt_GLORe_jason2_v3, adt_GLORe_jason3_v3, adt_GLORe_n1_v3, 
+             adt_GLORe_saral_v3, adt_GLORe_sentinel3a_v3, adt_GLORe_sentinel3b_v3, adt_GLORe_sentinel6a_v3, adt_GLORe_swot_v3, adt_GLORe_topex_poseidon_v3, 
              adt_nesdis_cryosat2_v2, adt_nesdis_cryosat2_v3, adt_nesdis_cryosat2_12_v2, adt_nesdis_cryosat2_12_v3, adt_nesdis_ers1_v2, adt_nesdis_ers1_v3, adt_nesdis_ers2_v2, adt_nesdis_ers2_v3,
              adt_nesdis_jason2_v2, adt_nesdis_jason2_v3, adt_nesdis_jason2_12_v2, adt_nesdis_jason2_12_v3, adt_nesdis_jason3_v2,
              adt_nesdis_jason3_v3, adt_nesdis_jason3_12_v2, adt_nesdis_jason3_12_v3, adt_nesdis_saral_v2, adt_nesdis_saral_v3, 

--- a/src/automation/ocn_dicts.py
+++ b/src/automation/ocn_dicts.py
@@ -1,6 +1,126 @@
 import automation_utils as au
 from automation_utils import InventoryInfo
 
+adt_GLORe_cryosat2_v3 = InventoryInfo(
+    obs_name='adt_GLORe_cryosat2_v3',
+    key='observations/reanalysis/adt/GLORe/cryosat2/%Y/%m/iodav3/adt.c2.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20100716T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/cryosat2/%Y/%m/iodav3/',
+    files='adt.c2.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_GFO_v3 = InventoryInfo(
+    obs_name='adt_GLORe_GFO_v3',
+    key='observations/reanalysis/adt/GLORe/GFO/%Y/%m/iodav3/adt.g1.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20000107T180000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/GFO/%Y/%m/iodav3/',
+    files='adt.g1.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_jason1_v3 = InventoryInfo(
+    obs_name='adt_GLORe_jason1_v3',
+    key='observations/reanalysis/adt/GLORe/jason1/%Y/%m/iodav3/adt.j1.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20020115T060000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/jason1/%Y/%m/iodav3/',
+    files='adt.j1.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_jason2_v3 = InventoryInfo(
+    obs_name='adt_GLORe_jason2_v3',
+    key='observations/reanalysis/adt/GLORe/jason2/%Y/%m/iodav3/adt.j2.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20080712T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/jason2/%Y/%m/iodav3/',
+    files='adt.j2.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_jason3_v3 = InventoryInfo(
+    obs_name='adt_GLORe_jason3_v3',
+    key='observations/reanalysis/adt/GLORe/jason3/%Y/%m/iodav3/adt.j3.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20160217T120000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/jason3/%Y/%m/iodav3/',
+    files='adt.j3.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_saral_v3 = InventoryInfo(
+    obs_name='adt_GLORe_saral_v3',
+    key='observations/reanalysis/adt/GLORe/saral/%Y/%m/iodav3/adt.sa.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20130315T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/saral/%Y/%m/iodav3/',
+    files='adt.sa.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_sentinel3a_v3 = InventoryInfo(
+    obs_name='adt_GLORe_sentinel3a_v3',
+    key='observations/reanalysis/adt/GLORe/sentinel3a/%Y/%m/iodav3/adt.3a.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20160301T120000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/sentinel3a/%Y/%m/iodav3/',
+    files='adt.3a.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_sentinel3b_v3 = InventoryInfo(
+    obs_name='adt_GLORe_sentinel3b_v3',
+    key='observations/reanalysis/adt/GLORe/sentinel3b/%Y/%m/iodav3/adt.3b.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20180526T180000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/sentinel3b/%Y/%m/iodav3/',
+    files='adt.3b.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_sentinel6a_v3 = InventoryInfo(
+    obs_name='adt_GLORe_sentinel6a_v3',
+    key='observations/reanalysis/adt/GLORe/sentinel6a/%Y/%m/iodav3/adt.6a.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='20220111T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/sentinel6a/%Y/%m/iodav3/',
+    files='adt.6a.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
+adt_GLORe_topex_poseidon_v3 = InventoryInfo(
+    obs_name='adt_GLORe_topex_poseidon_v3',
+    key='observations/reanalysis/adt/GLORe/topex_poseidon/%Y/%m/iodav3/adt.tx.%Y%m%d.T%H%M%SZ.iodav3.nc',
+    start='19930101T000000Z',
+    s3_prefix='observations/reanalysis/adt/GLORe/topex_poseidon/%Y/%m/iodav3/',
+    files='adt.tx.%z.iodav3.nc',
+    inv_cmd=au.HV_IODA_META,
+    platform=au.CLEAN_PLATFORM,
+    cycling_interval=au.CYCLING_6H,
+    s3_bucket=au.REANALYSIS_BUCKET,
+)
+
 adt_nesdis_cryosat2_v2 = InventoryInfo(
     obs_name='adt_nesdis_cryosat2_v2',
     key='observations/reanalysis/adt/nesdis/cryosat2/%Y/%m/24h/iodav2/cryosat2.nesdis.adt.%Y%m%d.T%H%M%SZ.iodav2.nc',
@@ -853,7 +973,9 @@ insitu_wod_xbt = InventoryInfo(
     s3_bucket=au.REANALYSIS_BUCKET
 )
 
-ocn_infos = [adt_nesdis_cryosat2_v2, adt_nesdis_cryosat2_v3, adt_nesdis_cryosat2_12_v2, adt_nesdis_cryosat2_12_v3, adt_nesdis_ers1_v2, adt_nesdis_ers1_v3, adt_nesdis_ers2_v2, adt_nesdis_ers2_v3,
+ocn_infos = [adt_GLORe_cryosat2_v3, adt_GLORe_GFO_v3, adt_GLORe_jason1_v3, adt_GLORe_jason2_v3, adt_GLORe_jason3_v3, adt_GLORe_saral_v3,
+             adt_GLORe_sentinel3a_v3, adt_GLORe_sentinel3b_v3, adt_GLORe_sentinel6a_v3, adt_GLORe_topex_poseidon_v3, 
+             adt_nesdis_cryosat2_v2, adt_nesdis_cryosat2_v3, adt_nesdis_cryosat2_12_v2, adt_nesdis_cryosat2_12_v3, adt_nesdis_ers1_v2, adt_nesdis_ers1_v3, adt_nesdis_ers2_v2, adt_nesdis_ers2_v3,
              adt_nesdis_jason2_v2, adt_nesdis_jason2_v3, adt_nesdis_jason2_12_v2, adt_nesdis_jason2_12_v3, adt_nesdis_jason3_v2,
              adt_nesdis_jason3_v3, adt_nesdis_jason3_12_v2, adt_nesdis_jason3_12_v3, adt_nesdis_saral_v2, adt_nesdis_saral_v3, 
              adt_nesdis_saral_12_v2, adt_nesdis_saral_12_v3, adt_nesdis_sentinel3a_v2, adt_nesdis_sentinel3a_v3, adt_nesdis_sentinel3a_12_v2, 


### PR DESCRIPTION
This adds new dictionaries to the automation system to cover the recently added GLORe ADT data into NNJA. Note, there is one folder that has not been updated but won't be completed for a few weeks (e1) that will be addressed in a subsequent PR when the data is updated to the correct format. 

A test was run in the test database and confirms that the plotting scripts pick up the new data after inventory so only changes are adding the dictionaries. 